### PR TITLE
Add --exclude flag to skip directories during recursive upload

### DIFF
--- a/backend/configmanager.go
+++ b/backend/configmanager.go
@@ -29,6 +29,7 @@ type Config struct {
 	AlbumName                     string   `json:"albumName" koanf:"album_name"`
 	AlbumAutoMode                 bool     `json:"albumAutoMode" koanf:"album_auto_mode"`
 	SetDateFromFilename           bool     `json:"setDateFromFilename" koanf:"set_date_from_filename"`
+	ExcludePattern                string   `json:"excludePattern" koanf:"exclude_pattern"`
 }
 
 type ConfigManager struct{}
@@ -132,6 +133,17 @@ func GetAlbumConfig() (albumName string, autoMode bool) {
 func (g *ConfigManager) SetSetDateFromFilename(v bool) {
 	AppConfig.SetDateFromFilename = v
 	_ = saveAppConfig()
+}
+
+func (g *ConfigManager) SetExcludePattern(pattern string) {
+	AppConfig.ExcludePattern = pattern
+	_ = saveAppConfig()
+}
+
+func (g *ConfigManager) GetExcludePattern() string {
+	configMu.RLock()
+	defer configMu.RUnlock()
+	return AppConfig.ExcludePattern
 }
 
 func (g *ConfigManager) AddCredentials(newAuthString string) error {

--- a/backend/upload.go
+++ b/backend/upload.go
@@ -336,7 +336,7 @@ func isSupportedByGooglePhotos(filename string) bool {
 	return supportedFormats[ext[1:]]
 }
 
-func scanDirectoryForFiles(path string, recursive bool) ([]string, error) {
+func scanDirectoryForFiles(path string, recursive bool, excludePattern string) ([]string, error) {
 	var files []string
 
 	entries, err := os.ReadDir(path)
@@ -347,11 +347,12 @@ func scanDirectoryForFiles(path string, recursive bool) ([]string, error) {
 	for _, entry := range entries {
 		fullPath := filepath.Join(path, entry.Name())
 		if entry.IsDir() {
+			if excludePattern != "" && entry.Name() == excludePattern {
+				continue
+			}
 			if recursive {
-				subFiles, err := scanDirectoryForFiles(fullPath, recursive)
+				subFiles, err := scanDirectoryForFiles(fullPath, recursive, excludePattern)
 				if err != nil {
-					// Log error and continue with other directories instead of failing
-					// This handles permission errors, broken symlinks, etc.
 					continue
 				}
 				files = append(files, subFiles...)
@@ -380,7 +381,7 @@ func filterGooglePhotosFiles(paths []string) ([]string, error) {
 		}
 
 		if fileInfo.IsDir() {
-			files, err := scanDirectoryForFiles(path, AppConfig.Recursive)
+			files, err := scanDirectoryForFiles(path, AppConfig.Recursive, AppConfig.ExcludePattern)
 			if err != nil {
 				return nil, fmt.Errorf("error scanning directory %s: %v", path, err)
 			}

--- a/cli.go
+++ b/cli.go
@@ -21,6 +21,7 @@ type cliConfig struct {
 	deleteFromHost                bool
 	disableUnsupportedFilesFilter bool
 	setDateFromFilename           bool
+	excludePattern                string
 	logLevel                      string
 	configPath                    string
 	albumName                     string
@@ -278,6 +279,7 @@ func runCLIUpload(filePaths []string, config cliConfig) error {
 	backend.AppConfig.DeleteFromHost = config.deleteFromHost
 	backend.AppConfig.DisableUnsupportedFilesFilter = config.disableUnsupportedFilesFilter
 	backend.AppConfig.SetDateFromFilename = config.setDateFromFilename
+	backend.AppConfig.ExcludePattern = config.excludePattern
 
 	// Handle album option - check for AUTO mode
 	if strings.ToUpper(config.albumName) == "AUTO" {

--- a/cli_shared.go
+++ b/cli_shared.go
@@ -50,6 +50,7 @@ func runCLI() {
 			fmt.Println("  -d, --delete                 Delete from host after upload")
 			fmt.Println("  -df, --disable-filter        Disable file type filtering")
 			fmt.Println("  --date-from-filename         Set media date from filename (e.g. 20240709_182027.jpg)")
+			fmt.Println("  -e, --exclude <pattern>      Exclude directories whose name matches pattern (e.g. @eaDir)")
 			fmt.Println("  -a, --album <name>           Add uploaded files to album (creates if needed)")
 			fmt.Println("                               Use 'AUTO' to create albums based on folder names")
 			fmt.Println("  -l, --log-level <level>      Set log level: debug, info, warn, error (default: info)")
@@ -92,6 +93,11 @@ func runCLI() {
 				config.disableUnsupportedFilesFilter = true
 			case "--date-from-filename":
 				config.setDateFromFilename = true
+			case "--exclude", "-e":
+				if i+1 < len(os.Args) {
+					config.excludePattern = os.Args[i+1]
+					i++
+				}
 			case "--threads", "-t":
 				if i+1 < len(os.Args) {
 					_, _ = fmt.Sscanf(os.Args[i+1], "%d", &config.threads)


### PR DESCRIPTION
**Problem:** gotohp's `upload` command has no way to exclude directories by name during recursive walk. On Synology NAS, `@eaDir` thumbnail cache folders exist at every level of the photos directory tree, causing ~1M+ spurious upload attempts with 100% failures when `--recursive` is used.

**Solution:** Adds `--exclude <pattern>` / `-e <pattern>` flag to the `upload` command. When set to a non-empty string, any directory whose name matches the pattern is skipped during recursive walk (and none of its contents are scanned).

**Usage:** `gotohp upload /photos -r -e @eaDir`

**Behavior:**
- Empty string (default) = no exclusion, fully backward compatible
- Exact string match against directory name (not path, not glob)
- Pattern persists in config file for GUI users
- `ConfigManager` getter/setter added for GUI binding support

**Files changed (4):**
- `backend/configmanager.go` — `ExcludePattern` field in `Config` struct, `Get`/`Set` methods
- `cli.go` — `excludePattern` field in `cliConfig`, wired to `AppConfig`
- `cli_shared.go` — flag parsing and help text
- `backend/upload.go` — `scanDirectoryForFiles` skips matching directories