### PR TITLE
auth: support Android 13+ Photos upload tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Unofficial Google Photos Desktop GUI Client
 - Skips files already present in your account
 - CLI mode
 - Configurable, presistent upload settings (stored in "%system config path%/gotohp/gotohp.config")  
-    You can force local config by creating empty gotohp.config next to executable.
+   You can force local config by creating empty gotohp.config next to executable.
 
 ## [Download](https://github.com/xob0t/gotohp/releases/latest)
 
@@ -70,22 +70,22 @@ You only need to do this once.
 ### Option 1 - ReVanced. No root required
 
 1. Install Google Photos ReVanced on your android device/emulator.
-    - Install GmsCore [https://github.com/ReVanced/GmsCore/releases](https://github.com/ReVanced/GmsCore/releases)
-    - Install patched apk [https://github.com/j-hc/revanced-magisk-module/releases](https://github.com/j-hc/revanced-magisk-module/releases) or patch it yourself
+   - Install GmsCore [https://github.com/ReVanced/GmsCore/releases](https://github.com/ReVanced/GmsCore/releases)
+   - Install patched apk [https://github.com/j-hc/revanced-magisk-module/releases](https://github.com/j-hc/revanced-magisk-module/releases) or patch it yourself
 2. Connect the device to your PC via ADB.
 3. Open the terminal on your PC and execute
 
-    Windows
+   Windows
 
-    ```cmd
-    adb logcat | FINDSTR "auth%2Fphotos.native"
-    ```
+   ```cmd
+   adb logcat | FINDSTR "auth%2Fphotos.native"
+   ```
 
-    Linux/Mac
+   Linux/Mac
 
-    ```shell
-    adb logcat | grep "auth%2Fphotos.native"
-    ```
+   ```shell
+   adb logcat | grep "auth%2Fphotos.native"
+   ```
 
 4. If you are already using ReVanced - remove Google Account from GmsCore.
 5. Open Google Photos ReVanced on your device and log into your account.
@@ -98,31 +98,36 @@ You only need to do this once.
 <details>
   <summary><strong>Click to expand</strong></summary>
 
-1. Get a rooted android device or an emulator. Recommended Android versions 9-13
+1. Get a rooted android device or an emulator.
 2. Connect the device to your PC via ADB.
 3. Install [HTTP Toolkit](https://httptoolkit.com)
 4. In HTTP Toolkit, select Intercept - `Android Device via ADB`. Filter traffic with
 
-    ```text
-    contains(https://www.googleapis.com/auth/photos.native)
-    ```
+   ```text
+   contains(https://www.googleapis.com/auth/photos.native)
+   ```
 
-    Or if you have an older version of Google Photos, try
+   Or if you have an older version of Google Photos, try
 
-    ```text
-    contains(www.googleapis.com%2Fauth%2Fplus.photos.readwrite)
-    ```
+   ```text
+   contains(www.googleapis.com%2Fauth%2Fplus.photos.readwrite)
+   ```
 
 5. Open Google Photos app and login with your account.
 6. A single request should appear.  
    Copy request body as text.
+7. Add that credential string in gotohp.
+8. If gotohp asks for a token binding key, keep the rooted device connected and click `Read from ADB`. gotohp will read the account's `lstBindingKeyAlias` from Android AccountManager and save it into the credential.
 
 #### Troubleshooting
 
-- **No Auth Request Intercepted**  
+- **No Auth Request Intercepted**
   1. Log out of your Google account.
   2. Log in again.
   3. Try `Android App via Frida` interception method in HTTP Toolkit.
+- **Token binding key not found**
+  1. Make sure the same Google account is present on the connected device.
+  2. Make sure root is available to ADB.
 
 </details>
 

--- a/backend/api.go
+++ b/backend/api.go
@@ -124,6 +124,17 @@ func (a *Api) getAuthToken() (map[string]string, error) {
 	authRequestData.Del("it_caveat_types")
 	authRequestData.Del("assertion_jwt")
 
+	var tokenBinding *tokenBindingSession
+	if alias := authRequestData.Get("token_binding_alias"); alias != "" {
+		var assertionJWT string
+		tokenBinding, assertionJWT, err = newTokenBindingSession(alias)
+		if err != nil {
+			return nil, fmt.Errorf("failed to prepare token binding assertion: %w", err)
+		}
+		authRequestData.Set("assertion_jwt", assertionJWT)
+	}
+	stripTokenBindingPrivateParams(authRequestData)
+
 	headers := map[string]string{
 		"Accept-Encoding": "gzip",
 		"app":             "com.google.android.apps.photos",
@@ -183,6 +194,9 @@ func (a *Api) getAuthToken() (map[string]string, error) {
 		if len(parts) == 2 {
 			parsedAuthResponse[parts[0]] = parts[1]
 		}
+	}
+	if err := decryptTokenEncryptedResponse(parsedAuthResponse, tokenBinding); err != nil {
+		return nil, err
 	}
 
 	// Validate we got the required fields

--- a/backend/api.go
+++ b/backend/api.go
@@ -133,7 +133,7 @@ func (a *Api) getAuthToken() (map[string]string, error) {
 		}
 		authRequestData.Set("assertion_jwt", assertionJWT)
 	}
-	stripTokenBindingPrivateParams(authRequestData)
+	authRequestData.Del("token_binding_alias")
 
 	headers := map[string]string{
 		"Accept-Encoding": "gzip",

--- a/backend/configmanager.go
+++ b/backend/configmanager.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -199,6 +200,41 @@ func (g *ConfigManager) AddCredentials(newAuthString string) error {
 	return nil
 }
 
+func (g *ConfigManager) CredentialNeedsTokenBinding(authString string) bool {
+	params, err := url.ParseQuery(authString)
+	if err != nil {
+		return false
+	}
+	return credentialNeedsTokenBinding(params)
+}
+
+func (g *ConfigManager) AddTokenBindingAliasFromADB(email string) error {
+	email = strings.TrimSpace(email)
+	if email == "" {
+		return fmt.Errorf("email cannot be empty")
+	}
+
+	alias, err := extractTokenBindingAliasFromADB(email)
+	if err != nil {
+		return err
+	}
+
+	for i, cred := range AppConfig.Credentials {
+		params, err := url.ParseQuery(cred)
+		if err != nil {
+			continue
+		}
+		if params.Get("Email") != email {
+			continue
+		}
+		params.Set("token_binding_alias", alias)
+		AppConfig.Credentials[i] = params.Encode()
+		return saveAppConfig()
+	}
+
+	return fmt.Errorf("no credentials found for email %s", email)
+}
+
 func (g *ConfigManager) RemoveCredentials(email string) error {
 	if email == "" {
 		return fmt.Errorf("email cannot be empty")
@@ -236,6 +272,116 @@ func (g *ConfigManager) RemoveCredentials(email string) error {
 
 	_ = saveAppConfig()
 	return nil
+}
+
+func credentialNeedsTokenBinding(params url.Values) bool {
+	if params.Get("token_binding_alias") != "" {
+		return false
+	}
+	return params.Get("assertion_jwt") != "" ||
+		params.Get("check_tb_upgrade_eligible") != ""
+}
+
+func extractTokenBindingAliasFromADB(email string) (string, error) {
+	if _, err := exec.LookPath("adb"); err != nil {
+		return "", fmt.Errorf("adb was not found in PATH")
+	}
+
+	escapedEmail := strings.ReplaceAll(email, "'", "''")
+	sql := fmt.Sprintf(
+		"select extras.value from extras join accounts on accounts._id=extras.accounts_id where accounts.name='%s' and extras.key='lstBindingKeyAlias';",
+		escapedEmail,
+	)
+
+	devices, err := listADBDevices()
+	if err != nil {
+		return "", err
+	}
+
+	var failures []string
+	var reachableRoot bool
+	for _, device := range devices {
+		_ = exec.Command("adb", "-s", device, "root").Run()
+
+		out, err := runADBSQLite(device, sql, false)
+		if err != nil {
+			out, err = runADBSQLite(device, sql, true)
+		}
+		if err != nil {
+			failures = append(failures, fmt.Sprintf("%s: %s", device, cleanADBError(out)))
+			continue
+		}
+
+		reachableRoot = true
+		alias := strings.TrimSpace(out)
+		if alias == "" {
+			failures = append(failures, fmt.Sprintf("%s: no token binding key for %s", device, email))
+			continue
+		}
+		if !strings.HasPrefix(alias, tokenBindingECDSAAliasPrefix) {
+			failures = append(failures, fmt.Sprintf("%s: unsupported token binding key format", device))
+			continue
+		}
+
+		return alias, nil
+	}
+
+	if reachableRoot {
+		return "", fmt.Errorf("token binding alias not found for %s on any connected adb device (%s)", email, strings.Join(failures, "; "))
+	}
+	return "", fmt.Errorf("could not read Android AccountManager on any connected adb device; root is required (%s)", strings.Join(failures, "; "))
+}
+
+func listADBDevices() ([]string, error) {
+	out, err := exec.Command("adb", "devices").CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list adb devices: %s", cleanADBError(string(out)))
+	}
+
+	var devices []string
+	var unavailable []string
+	for _, line := range strings.Split(string(out), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 || fields[0] == "List" {
+			continue
+		}
+		switch fields[1] {
+		case "device":
+			devices = append(devices, fields[0])
+		case "offline", "unauthorized", "no permissions":
+			unavailable = append(unavailable, fmt.Sprintf("%s is %s", fields[0], fields[1]))
+		default:
+			unavailable = append(unavailable, fmt.Sprintf("%s is %s", fields[0], fields[1]))
+		}
+	}
+
+	if len(devices) == 0 {
+		if len(unavailable) > 0 {
+			return nil, fmt.Errorf("no usable adb devices found (%s)", strings.Join(unavailable, "; "))
+		}
+		return nil, fmt.Errorf("no adb devices found")
+	}
+
+	return devices, nil
+}
+
+func runADBSQLite(device string, sql string, useSU bool) (string, error) {
+	args := []string{"-s", device, "shell", "sqlite3", "/data/system_ce/0/accounts_ce.db"}
+	if useSU {
+		args = []string{"-s", device, "shell", "su", "-c", "sqlite3 /data/system_ce/0/accounts_ce.db"}
+	}
+	cmd := exec.Command("adb", args...)
+	cmd.Stdin = strings.NewReader(sql)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func cleanADBError(out string) string {
+	out = strings.TrimSpace(out)
+	if out == "" {
+		return "adb command failed"
+	}
+	return strings.Join(strings.Fields(out), " ")
 }
 
 func determineConfigPath() {

--- a/backend/tokenbinding.go
+++ b/backend/tokenbinding.go
@@ -7,17 +7,14 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"math/big"
-	"net/url"
 	"strings"
 	"time"
 
 	"github.com/tink-crypto/tink-go/v2/hybrid"
-	"github.com/tink-crypto/tink-go/v2/insecurecleartextkeyset"
 	"github.com/tink-crypto/tink-go/v2/keyset"
 )
 
@@ -209,73 +206,6 @@ func decryptTokenEncryptedResponse(parsed map[string]string, session *tokenBindi
 	return nil
 }
 
-func stripTokenBindingPrivateParams(values url.Values) {
-	for _, key := range []string{"token_binding_alias"} {
-		values.Del(key)
-	}
-}
-
-func authUserAgent(values url.Values, fallbackGMSVersion string) string {
-	gmsVersion := fallbackGMSVersion
-	if gmsVersion == "" {
-		gmsVersion = "261631032"
-	}
-
-	androidVersion := values.Get("auth_android_version")
-	if androidVersion == "" {
-		androidVersion = androidVersionFromSDK(values.Get("sdk_version"))
-	}
-	if androidVersion == "" {
-		androidVersion = "13"
-	}
-
-	language := strings.ReplaceAll(values.Get("lang"), "-", "_")
-	if language == "" {
-		language = "en_US"
-	}
-
-	model := values.Get("auth_device_model")
-	if model == "" {
-		if androidVersion == "36" {
-			model = "CPH2769"
-		} else {
-			model = "WayDroid x86_64 Device"
-		}
-	}
-
-	buildID := values.Get("auth_build_id")
-	if buildID == "" {
-		if androidVersion == "36" {
-			buildID = "BP2A.250605.015"
-		} else {
-			buildID = "TQ3A.230901.001"
-		}
-	}
-
-	return fmt.Sprintf("com.google.android.gms/%s (Linux; U; Android %s; %s; %s; Build/%s; Cronet/147.0.7727.49)", gmsVersion, androidVersion, language, model, buildID)
-}
-
-func androidVersionFromSDK(sdkVersion string) string {
-	switch sdkVersion {
-	case "36":
-		return "16"
-	case "35":
-		return "15"
-	case "34":
-		return "14"
-	case "33":
-		return "13"
-	default:
-		return sdkVersion
-	}
-}
-
-func stripAuthPrivateParams(values url.Values) {
-	for _, key := range []string{"auth_android_version", "auth_device_model", "auth_build_id"} {
-		values.Del(key)
-	}
-}
-
 func decodeBase64URL(s string) ([]byte, error) {
 	if out, err := base64.RawURLEncoding.DecodeString(s); err == nil {
 		return out, nil
@@ -366,17 +296,4 @@ func aliasType(alias string) string {
 		}
 	}
 	return alias
-}
-
-func sha256Hex(b []byte) string {
-	h := sha256.Sum256(b)
-	return hex.EncodeToString(h[:])
-}
-
-func tokenBindingKeysetMaterialForTest(handle *keyset.Handle) ([]byte, error) {
-	buf := &bytes.Buffer{}
-	if err := insecurecleartextkeyset.Write(handle, keyset.NewBinaryWriter(buf)); err != nil {
-		return nil, err
-	}
-	return buf.Bytes(), nil
 }

--- a/backend/tokenbinding.go
+++ b/backend/tokenbinding.go
@@ -1,0 +1,382 @@
+package backend
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/big"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/tink-crypto/tink-go/v2/hybrid"
+	"github.com/tink-crypto/tink-go/v2/insecurecleartextkeyset"
+	"github.com/tink-crypto/tink-go/v2/keyset"
+)
+
+const tokenBindingECDSAAliasPrefix = "auth_account:ecdsa_keypair:"
+
+type tokenBindingSession struct {
+	privateKeyset *keyset.Handle
+}
+
+type tokenBindingAliasKey struct {
+	privatePKCS8 []byte
+	publicSPKI   []byte
+}
+
+func newTokenBindingSession(alias string) (*tokenBindingSession, string, error) {
+	bindingKey, err := parseTokenBindingECDSAAlias(alias)
+	if err != nil {
+		return nil, "", err
+	}
+
+	privateKey, err := parseTokenBindingPrivateKey(bindingKey.privatePKCS8)
+	if err != nil {
+		return nil, "", err
+	}
+
+	publicHash := sha256.Sum256(bindingKey.publicSPKI)
+	issuer := base64.RawURLEncoding.EncodeToString(publicHash[:])
+
+	privateHandle, publicKeyset, err := generateTokenBindingKeyset()
+	if err != nil {
+		return nil, "", err
+	}
+
+	assertionJWT, err := buildTokenBindingAssertionJWT(privateKey, issuer, base64.RawURLEncoding.EncodeToString(publicKeyset))
+	if err != nil {
+		return nil, "", err
+	}
+
+	return &tokenBindingSession{privateKeyset: privateHandle}, assertionJWT, nil
+}
+
+func (s *tokenBindingSession) decryptToken(encryptedToken string) (string, error) {
+	if s == nil || s.privateKeyset == nil {
+		return "", errors.New("token binding private keyset is unavailable")
+	}
+
+	ciphertext, err := decodeBase64URL(encryptedToken)
+	if err != nil {
+		return "", fmt.Errorf("failed to decode encrypted token: %w", err)
+	}
+
+	decryptor, err := hybrid.NewHybridDecrypt(s.privateKeyset)
+	if err != nil {
+		return "", fmt.Errorf("failed to create hybrid decrypt primitive: %w", err)
+	}
+
+	plaintext, err := decryptor.Decrypt(ciphertext, []byte{})
+	if err != nil {
+		return "", fmt.Errorf("failed to decrypt token: %w", err)
+	}
+
+	return string(plaintext), nil
+}
+
+func parseTokenBindingECDSAAlias(alias string) (*tokenBindingAliasKey, error) {
+	if !strings.HasPrefix(alias, tokenBindingECDSAAliasPrefix) {
+		return nil, fmt.Errorf("unsupported token binding alias type %q", aliasType(alias))
+	}
+
+	raw, err := decodeBase64URL(strings.TrimPrefix(alias, tokenBindingECDSAAliasPrefix))
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode token binding alias: %w", err)
+	}
+
+	fields, err := parseLengthDelimitedProtoFields(raw)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse token binding alias: %w", err)
+	}
+
+	key := &tokenBindingAliasKey{
+		privatePKCS8: firstBytesField(fields[1]),
+		publicSPKI:   firstBytesField(fields[2]),
+	}
+	if len(key.privatePKCS8) == 0 || len(key.publicSPKI) == 0 {
+		return nil, errors.New("token binding alias is missing private or public key material")
+	}
+
+	return key, nil
+}
+
+func parseTokenBindingPrivateKey(pkcs8 []byte) (*ecdsa.PrivateKey, error) {
+	key, err := x509.ParsePKCS8PrivateKey(pkcs8)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse token binding private key: %w", err)
+	}
+
+	ecdsaKey, ok := key.(*ecdsa.PrivateKey)
+	if !ok {
+		return nil, errors.New("token binding private key is not ECDSA")
+	}
+
+	return ecdsaKey, nil
+}
+
+func generateTokenBindingKeyset() (*keyset.Handle, []byte, error) {
+	manager := keyset.NewManager()
+	keyID, err := manager.Add(hybrid.ECIESHKDFAES128GCMKeyTemplate())
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate token binding key: %w", err)
+	}
+	if err := manager.SetPrimary(keyID); err != nil {
+		return nil, nil, fmt.Errorf("failed to set token binding primary key: %w", err)
+	}
+
+	privateHandle, err := manager.Handle()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create token binding keyset handle: %w", err)
+	}
+
+	publicHandle, err := privateHandle.Public()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create token binding public keyset: %w", err)
+	}
+
+	publicKeyset := &bytes.Buffer{}
+	if err := publicHandle.WriteWithNoSecrets(keyset.NewBinaryWriter(publicKeyset)); err != nil {
+		return nil, nil, fmt.Errorf("failed to serialize token binding public keyset: %w", err)
+	}
+
+	return privateHandle, publicKeyset.Bytes(), nil
+}
+
+func buildTokenBindingAssertionJWT(signingKey *ecdsa.PrivateKey, issuer string, publicKeysetB64 string) (string, error) {
+	header := map[string]string{"alg": "ES256", "typ": "JWT"}
+	payload := map[string]any{
+		"namespace": "TokenBinding",
+		"aud":       "https://accounts.google.com/accountmanager",
+		"iss":       issuer,
+		"iat":       time.Now().Unix(),
+		"ephemeral_key": map[string]string{
+			"kty":                     "type.googleapis.com/google.crypto.tink.EciesAeadHkdfPublicKey",
+			"TinkKeysetPublicKeyInfo": publicKeysetB64,
+		},
+	}
+
+	headerJSON, err := json.Marshal(header)
+	if err != nil {
+		return "", err
+	}
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+
+	signingInput := base64.RawURLEncoding.EncodeToString(headerJSON) + "." + base64.RawURLEncoding.EncodeToString(payloadJSON)
+	digest := sha256.Sum256([]byte(signingInput))
+	r, s, err := ecdsa.Sign(rand.Reader, signingKey, digest[:])
+	if err != nil {
+		return "", fmt.Errorf("failed to sign assertion JWT: %w", err)
+	}
+
+	signature := fixedWidthP256Int(r)
+	signature = append(signature, fixedWidthP256Int(s)...)
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(signature), nil
+}
+
+func decryptTokenEncryptedResponse(parsed map[string]string, session *tokenBindingSession) error {
+	if parsed["TokenEncrypted"] != "1" {
+		return nil
+	}
+	if session == nil {
+		return errors.New("auth response returned TokenEncrypted=1 but credential has no token_binding_alias")
+	}
+
+	encryptedToken := parsed["Auth"]
+	if encryptedToken == "" {
+		if parsed["it"] != "" {
+			return errors.New("auth response returned encrypted it token; remove it_caveat_types to request encrypted Auth")
+		}
+		return errors.New("auth response returned TokenEncrypted=1 but no encrypted Auth field was present")
+	}
+
+	plaintext, err := session.decryptToken(encryptedToken)
+	if err != nil {
+		return err
+	}
+
+	parsed["Auth"] = plaintext
+	return nil
+}
+
+func stripTokenBindingPrivateParams(values url.Values) {
+	for _, key := range []string{"token_binding_alias"} {
+		values.Del(key)
+	}
+}
+
+func authUserAgent(values url.Values, fallbackGMSVersion string) string {
+	gmsVersion := fallbackGMSVersion
+	if gmsVersion == "" {
+		gmsVersion = "261631032"
+	}
+
+	androidVersion := values.Get("auth_android_version")
+	if androidVersion == "" {
+		androidVersion = androidVersionFromSDK(values.Get("sdk_version"))
+	}
+	if androidVersion == "" {
+		androidVersion = "13"
+	}
+
+	language := strings.ReplaceAll(values.Get("lang"), "-", "_")
+	if language == "" {
+		language = "en_US"
+	}
+
+	model := values.Get("auth_device_model")
+	if model == "" {
+		if androidVersion == "36" {
+			model = "CPH2769"
+		} else {
+			model = "WayDroid x86_64 Device"
+		}
+	}
+
+	buildID := values.Get("auth_build_id")
+	if buildID == "" {
+		if androidVersion == "36" {
+			buildID = "BP2A.250605.015"
+		} else {
+			buildID = "TQ3A.230901.001"
+		}
+	}
+
+	return fmt.Sprintf("com.google.android.gms/%s (Linux; U; Android %s; %s; %s; Build/%s; Cronet/147.0.7727.49)", gmsVersion, androidVersion, language, model, buildID)
+}
+
+func androidVersionFromSDK(sdkVersion string) string {
+	switch sdkVersion {
+	case "36":
+		return "16"
+	case "35":
+		return "15"
+	case "34":
+		return "14"
+	case "33":
+		return "13"
+	default:
+		return sdkVersion
+	}
+}
+
+func stripAuthPrivateParams(values url.Values) {
+	for _, key := range []string{"auth_android_version", "auth_device_model", "auth_build_id"} {
+		values.Del(key)
+	}
+}
+
+func decodeBase64URL(s string) ([]byte, error) {
+	if out, err := base64.RawURLEncoding.DecodeString(s); err == nil {
+		return out, nil
+	}
+	return base64.URLEncoding.DecodeString(s)
+}
+
+func fixedWidthP256Int(x *big.Int) []byte {
+	b := x.Bytes()
+	if len(b) > 32 {
+		return b[len(b)-32:]
+	}
+	out := make([]byte, 32)
+	copy(out[32-len(b):], b)
+	return out
+}
+
+func parseLengthDelimitedProtoFields(b []byte) (map[int][][]byte, error) {
+	out := map[int][][]byte{}
+	for offset := 0; offset < len(b); {
+		key, n, ok := readProtoVarint(b[offset:])
+		if !ok {
+			return nil, fmt.Errorf("invalid protobuf key at offset %d", offset)
+		}
+		offset += n
+
+		fieldNumber := int(key >> 3)
+		wireType := int(key & 7)
+		switch wireType {
+		case 0:
+			_, n, ok := readProtoVarint(b[offset:])
+			if !ok {
+				return nil, fmt.Errorf("invalid protobuf varint at field %d", fieldNumber)
+			}
+			offset += n
+		case 1:
+			offset += 8
+		case 2:
+			fieldLen, n, ok := readProtoVarint(b[offset:])
+			if !ok {
+				return nil, fmt.Errorf("invalid protobuf length at field %d", fieldNumber)
+			}
+			offset += n
+			if fieldLen > uint64(len(b)-offset) {
+				return nil, fmt.Errorf("protobuf field %d overruns message", fieldNumber)
+			}
+			out[fieldNumber] = append(out[fieldNumber], append([]byte(nil), b[offset:offset+int(fieldLen)]...))
+			offset += int(fieldLen)
+		case 5:
+			offset += 4
+		default:
+			return nil, fmt.Errorf("unsupported protobuf wire type %d", wireType)
+		}
+
+		if offset > len(b) {
+			return nil, errors.New("protobuf field overruns message")
+		}
+	}
+	return out, nil
+}
+
+func readProtoVarint(b []byte) (uint64, int, bool) {
+	var value uint64
+	for i, c := range b {
+		if i == 10 {
+			return 0, 0, false
+		}
+		value |= uint64(c&0x7f) << (7 * i)
+		if c&0x80 == 0 {
+			return value, i + 1, true
+		}
+	}
+	return 0, 0, false
+}
+
+func firstBytesField(fields [][]byte) []byte {
+	if len(fields) == 0 {
+		return nil
+	}
+	return fields[0]
+}
+
+func aliasType(alias string) string {
+	if idx := strings.Index(alias, ":"); idx >= 0 {
+		parts := strings.Split(alias, ":")
+		if len(parts) >= 2 {
+			return strings.Join(parts[:min(len(parts), 3)], ":")
+		}
+	}
+	return alias
+}
+
+func sha256Hex(b []byte) string {
+	h := sha256.Sum256(b)
+	return hex.EncodeToString(h[:])
+}
+
+func tokenBindingKeysetMaterialForTest(handle *keyset.Handle) ([]byte, error) {
+	buf := &bytes.Buffer{}
+	if err := insecurecleartextkeyset.Write(handle, keyset.NewBinaryWriter(buf)); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/frontend/bindings/app/backend/configmanager.ts
+++ b/frontend/bindings/app/backend/configmanager.ts
@@ -13,6 +13,14 @@ export function AddCredentials(newAuthString: string): $CancellablePromise<void>
     return $Call.ByID(4083250689, newAuthString);
 }
 
+export function AddTokenBindingAliasFromADB(email: string): $CancellablePromise<void> {
+    return $Call.ByID(3252041498, email);
+}
+
+export function CredentialNeedsTokenBinding(authString: string): $CancellablePromise<boolean> {
+    return $Call.ByID(920629710, authString);
+}
+
 export function GetAlbumAutoMode(): $CancellablePromise<boolean> {
     return $Call.ByID(492228705);
 }
@@ -25,6 +33,10 @@ export function GetConfig(): $CancellablePromise<$models.Config> {
     return $Call.ByID(815152812).then(($result: any) => {
         return $$createType0($result);
     });
+}
+
+export function GetExcludePattern(): $CancellablePromise<string> {
+    return $Call.ByID(2942848526);
 }
 
 export function RemoveCredentials(email: string): $CancellablePromise<void> {
@@ -45,6 +57,10 @@ export function SetDeleteFromHost(deleteFromHost: boolean): $CancellablePromise<
 
 export function SetDisableUnsupportedFilesFilter(disableUnsupportedFilesFilter: boolean): $CancellablePromise<void> {
     return $Call.ByID(821557574, disableUnsupportedFilesFilter);
+}
+
+export function SetExcludePattern(pattern: string): $CancellablePromise<void> {
+    return $Call.ByID(4021766002, pattern);
 }
 
 export function SetForceUpload(forceUpload: boolean): $CancellablePromise<void> {

--- a/frontend/bindings/app/backend/models.ts
+++ b/frontend/bindings/app/backend/models.ts
@@ -91,6 +91,7 @@ export class Config {
     "albumName": string;
     "albumAutoMode": boolean;
     "setDateFromFilename": boolean;
+    "excludePattern": string;
 
     /** Creates a new Config instance. */
     constructor($$source: Partial<Config> = {}) {
@@ -132,6 +133,9 @@ export class Config {
         }
         if (!("setDateFromFilename" in $$source)) {
             this["setDateFromFilename"] = false;
+        }
+        if (!("excludePattern" in $$source)) {
+            this["excludePattern"] = "";
         }
 
         Object.assign(this, $$source);

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -36,6 +36,8 @@ const selectedOption = ref('')
 const options = ref<string[]>([])
 const credentialMap = ref<Record<string, string>>({})
 const albumNameOrKey = ref('')
+const tokenBindingEmail = ref('')
+const isExtractingTokenBinding = ref(false)
 
 function extractEmailFromCredential(credential: string): string | null {
   try {
@@ -51,13 +53,28 @@ watch(selectedOption, async (newValue) => {
   if (newValue) {
     try {
       await ConfigManager.SetSelected(newValue)
+      await updateTokenBindingPrompt(newValue)
       console.log('Successfully updated selected value:', newValue)
     } catch (error) {
       console.error('Failed to update selected value:', error)
       toast.error('Failed to update selected account.')
     }
+  } else {
+    tokenBindingEmail.value = ''
   }
 })
+
+async function updateTokenBindingPrompt(email: string) {
+  const credential = credentialMap.value[email]
+  if (!credential) {
+    tokenBindingEmail.value = ''
+    return
+  }
+
+  tokenBindingEmail.value = await ConfigManager.CredentialNeedsTokenBinding(credential)
+    ? email
+    : ''
+}
 
 async function addCredentials(authString: string) {
   try {
@@ -70,6 +87,7 @@ async function addCredentials(authString: string) {
         options.value = [...options.value, email]
       }
       selectedOption.value = email
+      await updateTokenBindingPrompt(email)
     }
     toast.success('Credentials added successfully!')
     return true
@@ -79,6 +97,46 @@ async function addCredentials(authString: string) {
       description: error instanceof Error ? error.message : String(error),
     })
     return false
+  }
+}
+
+async function refreshCredentials() {
+  const config = await ConfigManager.GetConfig()
+  credentialMap.value = {}
+  options.value = []
+
+  if (config.credentials?.length) {
+    config.credentials.forEach(credential => {
+      const email = extractEmailFromCredential(credential)
+      if (email) {
+        credentialMap.value[email] = credential
+        options.value.push(email)
+      }
+    })
+  }
+
+  if (config.selected) {
+    selectedOption.value = config.selected
+    await updateTokenBindingPrompt(config.selected)
+  }
+}
+
+async function addTokenBindingAliasFromADB() {
+  if (!tokenBindingEmail.value) return
+
+  isExtractingTokenBinding.value = true
+  try {
+    await ConfigManager.AddTokenBindingAliasFromADB(tokenBindingEmail.value)
+    await refreshCredentials()
+    tokenBindingEmail.value = ''
+    toast.success('Token binding key added.')
+  } catch (error) {
+    console.error('Failed to add token binding key:', error)
+    toast.error('Failed to add token binding key', {
+      description: error instanceof Error ? error.message : String(error),
+    })
+  } finally {
+    isExtractingTokenBinding.value = false
   }
 }
 
@@ -92,6 +150,9 @@ async function removeCredentials(email: string) {
       if (selectedOption.value === email) {
         selectedOption.value = ''
       }
+      if (tokenBindingEmail.value === email) {
+        tokenBindingEmail.value = ''
+      }
     }
     toast.success('Credentials removed.')
     return true
@@ -103,23 +164,7 @@ async function removeCredentials(email: string) {
 }
 
 onMounted(async () => {
-  const config = await ConfigManager.GetConfig()
-  if (config.credentials?.length) {
-    credentialMap.value = {}
-    options.value = []
-
-    config.credentials.forEach(credential => {
-      const email = extractEmailFromCredential(credential)
-      if (email) {
-        credentialMap.value[email] = credential
-        options.value.push(email)
-      }
-    })
-
-    if (config.selected) {
-      selectedOption.value = config.selected
-    }
-  }
+  await refreshCredentials()
 
 })
 
@@ -326,6 +371,22 @@ onUnmounted(() => {
           @item-added="addCredentials"
           @item-removed="removeCredentials"
         />
+        <div
+          v-if="tokenBindingEmail"
+          class="w-full max-w-xs border rounded-lg p-3 flex flex-col gap-3"
+          style="--wails-draggable: none"
+        >
+          <p class="text-sm text-muted-foreground">
+            This credential needs a token binding key from the rooted Android device it was captured from.
+          </p>
+          <Button
+            class="cursor-pointer select-none"
+            :disabled="isExtractingTokenBinding"
+            @click="addTokenBindingAliasFromADB"
+          >
+            {{ isExtractingTokenBinding ? 'Reading ADB...' : 'Read from ADB' }}
+          </Button>
+        </div>
       </template>
 
       <template v-else>
@@ -386,6 +447,22 @@ onUnmounted(() => {
             @item-added="addCredentials"
             @item-removed="removeCredentials"
           />
+          <div
+            v-if="tokenBindingEmail"
+            class="w-full max-w-xs border rounded-lg p-3 flex flex-col gap-3"
+            style="--wails-draggable: none"
+          >
+            <p class="text-sm text-muted-foreground">
+              This credential needs a token binding key from the rooted Android device it was captured from.
+            </p>
+            <Button
+              class="cursor-pointer select-none"
+              :disabled="isExtractingTokenBinding"
+              @click="addTokenBindingAliasFromADB"
+            >
+              {{ isExtractingTokenBinding ? 'Reading ADB...' : 'Read from ADB' }}
+            </Button>
+          </div>
 
           <Sheet>
             <SheetTrigger>

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/knadh/koanf/providers/file v1.2.0
 	github.com/knadh/koanf/providers/structs v1.0.0
 	github.com/knadh/koanf/v2 v2.3.0
+	github.com/tink-crypto/tink-go/v2 v2.6.0
 	github.com/wailsapp/wails/v3 v3.0.0-alpha.74
 	google.golang.org/protobuf v1.36.10
 )

--- a/go.sum
+++ b/go.sum
@@ -163,6 +163,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/tink-crypto/tink-go/v2 v2.6.0 h1:+KHNBHhWH33Vn+igZWcsgdEPUxKwBMEe0QC60t388v4=
+github.com/tink-crypto/tink-go/v2 v2.6.0/go.mod h1:2WbBA6pfNsAfBwDCggboaHeB2X29wkU8XHtGwh2YIk8=
 github.com/wailsapp/go-webview2 v1.0.23 h1:jmv8qhz1lHibCc79bMM/a/FqOnnzOGEisLav+a0b9P0=
 github.com/wailsapp/go-webview2 v1.0.23/go.mod h1:qJmWAmAmaniuKGZPWwne+uor3AHMB5PFhqiK0Bbj8kc=
 github.com/wailsapp/wails/v3 v3.0.0-alpha.74 h1:wRm1EiDQtxDisXk46NtpiBH90STwfKp36NrTDwOEdxw=


### PR DESCRIPTION
## Summary
- Keep the existing legacy and Android 13-style auth replay paths working.
- Add support for token-bound `TokenEncrypted=1` auth responses by generating a fresh `assertion_jwt` and decrypting the returned bearer token locally.
- Add a UI prompt for HTTP Toolkit credentials that need `token_binding_alias`.
- Add `Read from ADB`, which tries connected rooted devices and imports `lstBindingKeyAlias` from Android AccountManager.
- Update the official Google Photos credential docs to keep HTTP Toolkit for capture and use ADB only for the binding key.

References #43 and #44.

## Notes
- ReVanced/GmsCore credentials do not need this extra binding-key step.
- Official Google Photos credentials may need it when the captured auth data includes token-binding fields.
- Multiple connected ADB devices are handled by trying each online device until a matching key is found.

## Validation
- `go build -tags cli ./...`
- `npm run build`
- Local ADB import smoke test against a temp config succeeded.