### PR TITLE
fix: decode gzipped API error responses

### DIFF
--- a/backend/api.go
+++ b/backend/api.go
@@ -2,7 +2,6 @@ package backend
 
 import (
 	"bytes"
-	"compress/gzip"
 	"context"
 	"errors"
 	"fmt"
@@ -165,20 +164,12 @@ func (a *Api) getAuthToken() (map[string]string, error) {
 
 	// Check for errors
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := ReadResponseBody(resp)
 		return make(map[string]string), fmt.Errorf("request failed with status %d: %s", resp.StatusCode, string(body))
 	}
 
-	// Handle gzip encoding if present
-	var reader io.Reader
-	reader, err = gzip.NewReader(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create gzip reader: %w", err)
-	}
-	defer reader.(*gzip.Reader).Close()
-
 	// Parse the response body
-	bodyBytes, err := io.ReadAll(reader)
+	bodyBytes, err := ReadResponseBody(resp)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
@@ -268,7 +259,7 @@ func (a *Api) GetUploadToken(shaHashB64 string, fileSize int64) (string, error) 
 
 	// Check for errors
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := ReadResponseBody(resp)
 		return "", fmt.Errorf("request failed with status %d: %s", resp.StatusCode, string(body))
 	}
 
@@ -340,19 +331,12 @@ func (a *Api) FindRemoteMediaByHash(shaHash []byte) (string, error) {
 
 	// Check for errors
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := ReadResponseBody(resp)
 		return "", fmt.Errorf("request failed with status %d: %s", resp.StatusCode, string(body))
 	}
 
-	var reader io.Reader
-	reader, err = gzip.NewReader(resp.Body)
-	if err != nil {
-		return "", fmt.Errorf("failed to create gzip reader: %w", err)
-	}
-	defer reader.(*gzip.Reader).Close()
-
 	// Parse the response body
-	bodyBytes, err := io.ReadAll(reader)
+	bodyBytes, err := ReadResponseBody(resp)
 	if err != nil {
 		return "", fmt.Errorf("failed to read response body: %w", err)
 	}
@@ -470,11 +454,11 @@ func (a *Api) doUploadRequest(ctx context.Context, uploadURL string, reader io.R
 
 	// Check for non-success status codes (includes retryable 5xx/429 and non-retryable 4xx)
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := ReadResponseBody(resp)
 		return nil, fmt.Errorf("request failed with status %d: %s", resp.StatusCode, string(body))
 	}
 
-	bodyBytes, err := io.ReadAll(resp.Body)
+	bodyBytes, err := ReadResponseBody(resp)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
@@ -589,21 +573,11 @@ func (a *Api) doCommitRequest(serializedData []byte) (string, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := ReadResponseBody(resp)
 		return "", fmt.Errorf("request failed with status %d: %s", resp.StatusCode, string(body))
 	}
 
-	var reader io.Reader = resp.Body
-	if resp.Header.Get("Content-Encoding") == "gzip" {
-		gr, err := gzip.NewReader(resp.Body)
-		if err != nil {
-			return "", fmt.Errorf("failed to create gzip reader: %w", err)
-		}
-		defer gr.Close()
-		reader = gr
-	}
-
-	bodyBytes, err := io.ReadAll(reader)
+	bodyBytes, err := ReadResponseBody(resp)
 	if err != nil {
 		return "", fmt.Errorf("failed to read response body: %w", err)
 	}
@@ -698,22 +672,12 @@ func (a *Api) CreateAlbum(albumName string, mediaKeys []string) (string, error) 
 
 	// Check for errors
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := ReadResponseBody(resp)
 		return "", fmt.Errorf("request failed with status %d: %s", resp.StatusCode, string(body))
 	}
 
-	// Handle gzip response if needed
-	var reader io.Reader = resp.Body
-	if resp.Header.Get("Content-Encoding") == "gzip" {
-		reader, err = gzip.NewReader(resp.Body)
-		if err != nil {
-			return "", fmt.Errorf("failed to create gzip reader: %w", err)
-		}
-		defer reader.(*gzip.Reader).Close()
-	}
-
 	// Parse the response body
-	bodyBytes, err := io.ReadAll(reader)
+	bodyBytes, err := ReadResponseBody(resp)
 	if err != nil {
 		return "", fmt.Errorf("failed to read response body: %w", err)
 	}
@@ -798,7 +762,7 @@ func (a *Api) AddMediaToAlbum(albumMediaKey string, mediaKeys []string) error {
 
 	// Check for errors
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := ReadResponseBody(resp)
 		return fmt.Errorf("request failed with status %d: %s", resp.StatusCode, string(body))
 	}
 

--- a/backend/httpclient.go
+++ b/backend/httpclient.go
@@ -1,11 +1,13 @@
 package backend
 
 import (
+	"compress/gzip"
 	"fmt"
 	"io"
 	"math/rand"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 )
 
@@ -82,6 +84,19 @@ func CheckResponse(resp *http.Response) error {
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		return nil
 	}
-	body, _ := io.ReadAll(resp.Body)
+	body, _ := ReadResponseBody(resp)
 	return fmt.Errorf("request failed with status %d: %s", resp.StatusCode, string(body))
+}
+
+func ReadResponseBody(resp *http.Response) ([]byte, error) {
+	var reader io.Reader = resp.Body
+	if strings.Contains(strings.ToLower(resp.Header.Get("Content-Encoding")), "gzip") {
+		gzipReader, err := gzip.NewReader(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create gzip reader: %w", err)
+		}
+		defer gzipReader.Close()
+		reader = gzipReader
+	}
+	return io.ReadAll(reader)
 }

--- a/backend/upload.go
+++ b/backend/upload.go
@@ -95,10 +95,11 @@ type UploadBatchStart struct {
 }
 
 type FileUploadResult struct {
-	MediaKey string `json:"MediaKey"`
-	IsError  bool   `json:"IsError"`
-	Error    error  `json:"-"`
-	Path     string `json:"Path"`
+	MediaKey     string `json:"MediaKey"`
+	IsError      bool   `json:"IsError"`
+	Error        error  `json:"-"`
+	ErrorMessage string `json:"ErrorMessage"`
+	Path         string `json:"Path"`
 }
 
 type ThreadStatus struct {
@@ -125,8 +126,9 @@ func (m *UploadManager) Upload(app AppInterface, paths []string) {
 	targetPaths, err := filterGooglePhotosFiles(paths)
 	if err != nil {
 		app.EmitEvent("FileStatus", FileUploadResult{
-			IsError: true,
-			Error:   err,
+			IsError:      true,
+			Error:        err,
+			ErrorMessage: err.Error(),
 		})
 		return
 	}
@@ -604,7 +606,7 @@ func startUploadWorker(workerID int, workChan <-chan string, results chan<- File
 
 			mediaKey, err := uploadFileWithCallback(ctx, api, path, workerID, callback)
 			if err != nil {
-				results <- FileUploadResult{IsError: true, Error: err, Path: path}
+				results <- FileUploadResult{IsError: true, Error: err, ErrorMessage: err.Error(), Path: path}
 				app.EmitEvent("ThreadStatus", ThreadStatus{
 					WorkerID: workerID,
 					Status:   "error",

--- a/frontend/bindings/app/backend/models.ts
+++ b/frontend/bindings/app/backend/models.ts
@@ -157,6 +157,7 @@ export class Config {
 export class FileUploadResult {
     "MediaKey": string;
     "IsError": boolean;
+    "ErrorMessage": string;
     "Path": string;
 
     /** Creates a new FileUploadResult instance. */
@@ -166,6 +167,9 @@ export class FileUploadResult {
         }
         if (!("IsError" in $$source)) {
             this["IsError"] = false;
+        }
+        if (!("ErrorMessage" in $$source)) {
+            this["ErrorMessage"] = "";
         }
         if (!("Path" in $$source)) {
             this["Path"] = "";

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -16,8 +16,9 @@ import './index.css'
 import SettingsPanel from "./SettingsPanel.vue"
 import Upload from './Upload.vue'
 import { uploadManager } from './utils/UploadManager'
+import Toaster from './components/ui/sonner/Sonner.vue'
 
-import { toast, Toaster } from "vue-sonner"
+import { toast } from "vue-sonner"
 
 useColorMode().value = "dark"
 
@@ -266,12 +267,24 @@ const albumErrorHandler = (e: Event) => {
   }
 }
 
+const uploadErrorHandler = (e: Event) => {
+  const event = e as CustomEvent<{ FileName: string; Message: string }>
+  const { FileName, Message } = event.detail
+  const errorMessage = Message.replace(/^Error:\s*/, '')
+  toast.error(FileName ? `Upload failed: ${FileName}` : 'Upload failed', {
+    description: errorMessage,
+    duration: 10000,
+    important: true,
+  })
+}
+
 onMounted(() => {
   document.addEventListener('dragenter', onDragEnter)
   document.addEventListener('dragleave', onDragLeave)
   document.addEventListener('dragover', onDragOver)
   document.addEventListener('drop', onDrop)
   window.addEventListener('albumError', albumErrorHandler)
+  window.addEventListener('uploadError', uploadErrorHandler)
 
   // Listen for files-dropped event from backend
   Events.On('files-dropped', (event: { data: { files: string[]; dropZone: string } }) => {
@@ -302,6 +315,7 @@ onUnmounted(() => {
   document.removeEventListener('dragover', onDragOver)
   document.removeEventListener('drop', onDrop)
   window.removeEventListener('albumError', albumErrorHandler)
+  window.removeEventListener('uploadError', uploadErrorHandler)
   if (dragLeaveTimeout) {
     clearTimeout(dragLeaveTimeout)
   }
@@ -504,6 +518,11 @@ onUnmounted(() => {
     >
       <Upload />
     </div>
-    <Toaster position="bottom-center" />
+    <Toaster
+      position="bottom-center"
+      rich-colors
+      expand
+      :visible-toasts="4"
+    />
   </main>
 </template>

--- a/frontend/src/components/ThreadProgress.vue
+++ b/frontend/src/components/ThreadProgress.vue
@@ -50,6 +50,8 @@ const fileSizeDisplay = computed(() => {
   }
   return `${formatBytes(props.thread.BytesUploaded)}/${formatBytes(props.thread.BytesTotal)}`
 })
+
+const statusMessage = computed(() => props.thread.Message.replace(/^Error:\s*/, ''))
 </script>
 
 <template>
@@ -91,5 +93,11 @@ const fileSizeDisplay = computed(() => {
         <span>{{ uploadPercent }}%</span>
       </div>
     </template>
+    <p
+      v-else-if="thread.Status === 'error'"
+      class="mt-1 text-[11px] leading-snug text-destructive break-words"
+    >
+      {{ statusMessage }}
+    </p>
   </div>
 </template>

--- a/frontend/src/components/ui/sonner/Sonner.vue
+++ b/frontend/src/components/ui/sonner/Sonner.vue
@@ -13,7 +13,6 @@ const props = defineProps<ToasterProps>()
       '--normal-bg': 'var(--popover)',
       '--normal-text': 'var(--popover-foreground)',
       '--normal-border': 'var(--border)',
-
     }"
   />
 </template>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,4 +1,5 @@
 import { createApp } from 'vue'
 import App from './App.vue'
+import 'vue-sonner/style.css'
 
 createApp(App).mount('#app')

--- a/frontend/src/utils/UploadManager.ts
+++ b/frontend/src/utils/UploadManager.ts
@@ -15,6 +15,7 @@ export interface ThreadStatus {
 export interface FileUploadResult {
   MediaKey: string;
   IsError: boolean;
+  ErrorMessage: string;
   Path: string;
 }
 
@@ -144,20 +145,25 @@ class UploadManager {
           this.completedBytes += prevThread.BytesTotal;
         }
       }
+
+      if (thread.Status === 'error' && prevThread?.Message !== thread.Message) {
+        window.dispatchEvent(new CustomEvent('uploadError', { detail: thread }));
+      }
       
       this.state.threads.set(thread.WorkerID, thread);
       this.updateBytesAndSpeed();
     });
 
     // Handle file status updates
-    Events.On("FileStatus", (event: { data: { IsError: boolean; Path: string; MediaKey: string } }) => {
+    Events.On("FileStatus", (event: { data: FileUploadResult }) => {
       const { IsError, Path, MediaKey } = event.data;
 
       if (!IsError) {
         this.state.uploadedFiles += 1;
         this.state.results.success.push({ path: Path, mediaKey: MediaKey });
       } else {
-        this.state.results.fail.push(Path);
+        const errorMessage = event.data.ErrorMessage;
+        this.state.results.fail.push(errorMessage ? `${Path}: ${errorMessage}` : Path);
       }
     });
 


### PR DESCRIPTION
## Summary
- Add a shared response-body reader that decodes gzip responses before reading them.
- Use it for Google Photos/auth success and error responses so API errors are readable instead of compressed bytes.
- Include upload error text in frontend events.
- Import `vue-sonner/style.css` so Sonner's default rich-color toast layout is applied after the npm update.
- Show upload failures through Sonner's default rich-color error variant and keep the full error visible in the worker row.

## Validation
- `go build ./...`
- `npm run build`
- `npm run lint`
- `wails3 task windows:build PRODUCTION=true`

Note: Vite 8/Rolldown still emits `INVALID_ANNOTATION` warnings for pure comments inside `@vueuse/core`, but the production build exits successfully.

No regression tests were run, per repo instruction.