### PR TITLE
build: add standalone CLI release artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,6 +93,12 @@ jobs:
           # Build the app package
           wails3 task darwin:package:universal
 
+          # Build standalone CLI binary without Wails/WebView dependencies
+          CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -tags cli -trimpath -buildvcs=false -ldflags="-w -s" -o bin/gotohp-cli-amd64
+          CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -tags cli -trimpath -buildvcs=false -ldflags="-w -s" -o bin/gotohp-cli-arm64
+          lipo -create -output release/gotohp-cli-macos-universal bin/gotohp-cli-amd64 bin/gotohp-cli-arm64
+          rm bin/gotohp-cli-amd64 bin/gotohp-cli-arm64
+
           # Create zip file of the .app bundle
           cd bin
           zip -r ../release/gotohp-macos-universal.zip gotohp.app
@@ -115,7 +121,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: macos-release
-          path: release/gotohp-macos-universal.zip
+          path: |
+            release/gotohp-macos-universal.zip
+            release/gotohp-cli-macos-universal
 
       - name: Upload macOS Debug Artifact
         if: (github.event_name == 'workflow_dispatch' && inputs.build_debug) || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
@@ -127,7 +135,9 @@ jobs:
       - name: Upload to Draft Release
         uses: softprops/action-gh-release@v2
         with:
-          files: release/gotohp-macos-universal.zip
+          files: |
+            release/gotohp-macos-universal.zip
+            release/gotohp-cli-macos-universal
           tag_name: ${{ steps.set-tag.outputs.tag_name }}
           name: ${{ steps.set-tag.outputs.release_name }}
           body: ${{ steps.set-tag.outputs.release_body }}
@@ -201,9 +211,11 @@ jobs:
           task windows:build PRODUCTION=true
           Move-Item -Path "bin\gotohp.exe" -Destination "release\gotohp-x64.exe"
 
-          # Build the CLI-only application with production flags
-          task windows:build:cli PRODUCTION=true
-          Move-Item -Path "bin\gotohp-cli.exe" -Destination "release\gotohp-cli-x64.exe"
+          # Build standalone CLI binary without Wails/WebView dependencies
+          $env:CGO_ENABLED="0"
+          $env:GOOS="windows"
+          $env:GOARCH="amd64"
+          go build -tags cli -trimpath -buildvcs=false -ldflags="-w -s" -o "release\gotohp-cli-x64.exe"
 
       - name: Build Windows App (Debug)
         if: (github.event_name == 'workflow_dispatch' && inputs.build_debug) || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
@@ -217,9 +229,11 @@ jobs:
           wails3 build
           Move-Item -Path "bin\gotohp.exe" -Destination "release\gotohp-x64_debug.exe"
 
-          # Build CLI debug version
-          task windows:build:cli
-          Move-Item -Path "bin\gotohp-cli.exe" -Destination "release\gotohp-cli-x64_debug.exe"
+          # Build CLI debug version without Wails/WebView dependencies
+          $env:CGO_ENABLED="0"
+          $env:GOOS="windows"
+          $env:GOARCH="amd64"
+          go build -tags cli -buildvcs=false -gcflags=all="-l" -o "release\gotohp-cli-x64_debug.exe"
 
       - name: Upload Windows Release Artifact
         uses: actions/upload-artifact@v4
@@ -299,6 +313,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential libwebkit2gtk-4.1-dev gcc libgtk-3-dev pkg-config
 
+      - name: Install nfpm
+        run: go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest
+
       - name: Install Wails3
         run: go install -v github.com/wailsapp/wails/v3/cmd/wails3@latest
 
@@ -315,6 +332,11 @@ jobs:
 
           # Generate deb package
           wails3 tool package -name gotohp -format deb -config ./build/linux/nfpm/nfpm.yaml -out ./release
+
+          # Build CLI binary and package without Wails/WebView dependencies
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -tags cli -trimpath -buildvcs=false -ldflags="-w -s" -o "bin/gotohp-cli"
+          cp bin/gotohp-cli "release/gotohp-cli_amd64"
+          nfpm package --packager deb --config ./build/linux/nfpm/nfpm-cli.yaml --target ./release/gotohp-cli_amd64.deb
 
           # Generate AppImage
           wails3 package
@@ -345,6 +367,8 @@ jobs:
           path: |
             release/gotohp_amd64.deb
             release/gotohp_amd64.AppImage
+            release/gotohp-cli_amd64
+            release/gotohp-cli_amd64.deb
 
       - name: Upload Linux Debug Artifact
         if: (github.event_name == 'workflow_dispatch' && inputs.build_debug) || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
@@ -359,6 +383,8 @@ jobs:
           files: |
             release/gotohp_amd64.deb
             release/gotohp_amd64.AppImage
+            release/gotohp-cli_amd64
+            release/gotohp-cli_amd64.deb
           tag_name: ${{ steps.set-tag.outputs.tag_name }}
           name: ${{ steps.set-tag.outputs.release_name }}
           body: ${{ steps.set-tag.outputs.release_body }}

--- a/README.md
+++ b/README.md
@@ -19,17 +19,15 @@ Unofficial Google Photos Desktop GUI Client
 
 ## CLI Usage
 
-### Windows
+Releases include a standalone CLI executable for command-line usage. Use the `gotohp-cli` artifact for your platform; it does not depend on the GUI runtime.
 
-Windows releases include a dedicated CLI executable (`gotohp-cli.exe`) for command-line usage:
-
-```cmd
-gotohp-cli.exe upload C:\path\to\photos --recursive --threads 5
-gotohp-cli.exe upload C:\path\to\photos --recursive --exclude @eaDir
-gotohp-cli.exe creds list
-gotohp-cli.exe creds add "androidId=..."
-gotohp-cli.exe creds set user@gmail.com
-gotohp-cli.exe version
+```shell
+gotohp-cli upload /path/to/photos --recursive --threads 5
+gotohp-cli upload /path/to/photos --recursive --exclude @eaDir
+gotohp-cli creds list
+gotohp-cli creds add "androidId=..."
+gotohp-cli creds set user@gmail.com
+gotohp-cli version
 ```
 
 **Available commands:**
@@ -51,17 +49,6 @@ gotohp-cli.exe version
 - `creds set <email>` (alias: `select`) - Set active credential (supports partial matching)
 - `version` - Show version information
 - `help` - Show help message
-
-### macOS / Linux
-
-The main executable supports CLI mode:
-
-```bash
-./gotohp upload /path/to/photos --recursive --threads 5
-./gotohp upload /path/to/photos --recursive --exclude @eaDir
-./gotohp creds list
-./gotohp version
-```
 
 ## Requires mobile app credentials to work
 

--- a/backend/album.go
+++ b/backend/album.go
@@ -4,20 +4,12 @@ import (
 	"fmt"
 	"strings"
 	"time"
-
-	"github.com/wailsapp/wails/v3/pkg/application"
 )
 
 // AlbumError represents an album creation error
 type AlbumError struct {
 	AlbumName string `json:"AlbumName"`
 	Error     string `json:"Error"`
-}
-
-func init() {
-	application.RegisterEvent[AlbumStatus]("albumProgress")
-	application.RegisterEvent[AlbumStatus]("albumComplete")
-	application.RegisterEvent[AlbumError]("albumError")
 }
 
 const (

--- a/backend/upload.go
+++ b/backend/upload.go
@@ -8,8 +8,6 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-
-	"github.com/wailsapp/wails/v3/pkg/application"
 )
 
 // FilesDroppedEvent is emitted when files are dropped on any drop zone
@@ -21,17 +19,6 @@ type FilesDroppedEvent struct {
 // StartUploadEvent is received from frontend to start upload
 type StartUploadEvent struct {
 	Files []string `json:"files"`
-}
-
-func init() {
-	application.RegisterEvent[UploadBatchStart]("uploadStart")
-	application.RegisterEvent[application.Void]("uploadStop")
-	application.RegisterEvent[FileUploadResult]("FileStatus")
-	application.RegisterEvent[ThreadStatus]("ThreadStatus")
-	application.RegisterEvent[application.Void]("uploadCancel")
-	application.RegisterEvent[int64]("uploadTotalBytes")
-	application.RegisterEvent[FilesDroppedEvent]("files-dropped")
-	application.RegisterEvent[StartUploadEvent]("startUpload")
 }
 
 // ProgressCallback is a function type for upload progress updates

--- a/backend/wails_app.go
+++ b/backend/wails_app.go
@@ -1,3 +1,5 @@
+//go:build !cli
+
 package backend
 
 import (

--- a/backend/wails_events.go
+++ b/backend/wails_events.go
@@ -1,0 +1,19 @@
+//go:build !cli
+
+package backend
+
+import "github.com/wailsapp/wails/v3/pkg/application"
+
+func init() {
+	application.RegisterEvent[AlbumStatus]("albumProgress")
+	application.RegisterEvent[AlbumStatus]("albumComplete")
+	application.RegisterEvent[AlbumError]("albumError")
+	application.RegisterEvent[UploadBatchStart]("uploadStart")
+	application.RegisterEvent[application.Void]("uploadStop")
+	application.RegisterEvent[FileUploadResult]("FileStatus")
+	application.RegisterEvent[ThreadStatus]("ThreadStatus")
+	application.RegisterEvent[application.Void]("uploadCancel")
+	application.RegisterEvent[int64]("uploadTotalBytes")
+	application.RegisterEvent[FilesDroppedEvent]("files-dropped")
+	application.RegisterEvent[StartUploadEvent]("startUpload")
+}

--- a/build/darwin/Taskfile.yml
+++ b/build/darwin/Taskfile.yml
@@ -40,6 +40,38 @@ tasks:
       - lipo -create -output "{{.BIN_DIR}}/{{.APP_NAME}}" "{{.BIN_DIR}}/{{.APP_NAME}}-amd64" "{{.BIN_DIR}}/{{.APP_NAME}}-arm64"
       - rm "{{.BIN_DIR}}/{{.APP_NAME}}-amd64" "{{.BIN_DIR}}/{{.APP_NAME}}-arm64"
 
+  build:cli:
+    summary: Builds the CLI-only application for macOS
+    deps:
+      - task: common:go:mod:tidy
+    cmds:
+      - go build {{.BUILD_FLAGS}} -tags cli -o {{.OUTPUT}}
+    vars:
+      BUILD_FLAGS: '{{if eq .PRODUCTION "true"}}-trimpath -buildvcs=false -ldflags="-w -s"{{else}}-buildvcs=false{{end}}'
+      DEFAULT_OUTPUT: '{{.BIN_DIR}}/{{.APP_NAME}}-cli'
+      OUTPUT: '{{ .OUTPUT | default .DEFAULT_OUTPUT }}'
+    env:
+      GOOS: darwin
+      CGO_ENABLED: 0
+      GOARCH: '{{.ARCH | default ARCH}}'
+
+  build:cli:universal:
+    summary: Builds darwin universal CLI binary (arm64 + amd64)
+    deps:
+      - task: build:cli
+        vars:
+          ARCH: amd64
+          OUTPUT: "{{.BIN_DIR}}/{{.APP_NAME}}-cli-amd64"
+          PRODUCTION: '{{.PRODUCTION}}'
+      - task: build:cli
+        vars:
+          ARCH: arm64
+          OUTPUT: "{{.BIN_DIR}}/{{.APP_NAME}}-cli-arm64"
+          PRODUCTION: '{{.PRODUCTION}}'
+    cmds:
+      - lipo -create -output "{{.BIN_DIR}}/{{.APP_NAME}}-cli" "{{.BIN_DIR}}/{{.APP_NAME}}-cli-amd64" "{{.BIN_DIR}}/{{.APP_NAME}}-cli-arm64"
+      - rm "{{.BIN_DIR}}/{{.APP_NAME}}-cli-amd64" "{{.BIN_DIR}}/{{.APP_NAME}}-cli-arm64"
+
   package:
     summary: Packages a production build of the application into a `.app` bundle
     deps:

--- a/build/linux/Taskfile.yml
+++ b/build/linux/Taskfile.yml
@@ -20,6 +20,19 @@ tasks:
       GOARCH: '{{.ARCH | default ARCH}}'
       PRODUCTION: '{{.PRODUCTION | default "false"}}'
 
+  build:cli:
+    summary: Builds the CLI application for Linux
+    deps:
+      - task: common:go:mod:tidy
+    cmds:
+      - go build {{.BUILD_FLAGS}} -tags cli -o {{.BIN_DIR}}/{{.APP_NAME}}-cli
+    vars:
+      BUILD_FLAGS: '{{if eq .PRODUCTION "true"}}-trimpath -buildvcs=false -ldflags="-w -s"{{else}}-buildvcs=false{{end}}'
+    env:
+      GOOS: linux
+      CGO_ENABLED: 0
+      GOARCH: '{{.ARCH | default ARCH}}'
+
   package:
     summary: Packages a production build of the application for Linux
     deps:
@@ -85,6 +98,15 @@ tasks:
     summary: Creates a deb package
     cmds: 
       - wails3 tool package -name {{.APP_NAME}} -format deb -config ./build/linux/nfpm/nfpm.yaml -out {{.ROOT_DIR}}/bin
+
+  generate:cli:deb:
+    summary: Creates a deb package for the CLI binary
+    deps:
+      - task: build:cli
+        vars:
+          PRODUCTION: "true"
+    cmds:
+      - nfpm package --packager deb --config ./build/linux/nfpm/nfpm-cli.yaml --target {{.ROOT_DIR}}/bin/{{.APP_NAME}}-cli.deb
 
   generate:rpm:
     summary: Creates a rpm package

--- a/build/linux/nfpm/nfpm-cli.yaml
+++ b/build/linux/nfpm/nfpm-cli.yaml
@@ -1,0 +1,16 @@
+name: "gotohp-cli"
+arch: ${GOARCH}
+platform: "linux"
+version: "0.7.0"
+section: "utils"
+priority: "optional"
+maintainer: ${GIT_COMMITTER_NAME} <${GIT_COMMITTER_EMAIL}>
+description: "Google Photos unofficial client CLI"
+vendor: "xob0t"
+homepage: "https://github.com/xob0t/gotohp"
+license: "MIT"
+release: "1"
+
+contents:
+  - src: "./bin/gotohp-cli"
+    dst: "/usr/local/bin/gotohp-cli"

--- a/cli_name.go
+++ b/cli_name.go
@@ -1,0 +1,8 @@
+//go:build !cli
+
+package main
+
+const (
+	cliExecutableName = "gotohp"
+	cliHasGUI         = true
+)

--- a/cli_name_cli.go
+++ b/cli_name_cli.go
@@ -1,0 +1,8 @@
+//go:build cli
+
+package main
+
+const (
+	cliExecutableName = "gotohp-cli"
+	cliHasGUI         = false
+)

--- a/cli_shared.go
+++ b/cli_shared.go
@@ -42,7 +42,7 @@ func runCLI() {
 	case "upload":
 		// Check for help flag first
 		if len(os.Args) > 2 && (os.Args[2] == "--help" || os.Args[2] == "-h") {
-			fmt.Println("Usage: gotohp upload <filepath> [flags]")
+			fmt.Printf("Usage: %s upload <filepath> [flags]\n", cliExecutableName)
 			fmt.Println("\nFlags:")
 			fmt.Println("  -r, --recursive              Include subdirectories")
 			fmt.Println("  -t, --threads <n>            Number of upload threads (default: 3)")
@@ -60,8 +60,8 @@ func runCLI() {
 
 		if len(os.Args) < 3 {
 			fmt.Println("Error: filepath required")
-			fmt.Println("Usage: gotohp upload <filepath> [flags]")
-			fmt.Println("\nRun 'gotohp upload --help' for more information")
+			fmt.Printf("Usage: %s upload <filepath> [flags]\n", cliExecutableName)
+			fmt.Printf("\nRun '%s upload --help' for more information\n", cliExecutableName)
 			os.Exit(1)
 		}
 
@@ -174,8 +174,10 @@ func printCLIHelp() {
 	fmt.Println("gotohp - Google Photos unofficial client")
 	fmt.Println()
 	fmt.Println("Usage:")
-	fmt.Println("  gotohp              Launch GUI application")
-	fmt.Println("  gotohp <command>    Run CLI command")
+	if cliHasGUI {
+		fmt.Printf("  %s              Launch GUI application\n", cliExecutableName)
+	}
+	fmt.Printf("  %s <command>    Run CLI command\n", cliExecutableName)
 	fmt.Println()
 	fmt.Println("Commands:")
 	fmt.Println("  upload <filepath>   Upload a file to Google Photos")
@@ -183,11 +185,11 @@ func printCLIHelp() {
 	fmt.Println("  help                Show this help message")
 	fmt.Println("  version             Show version information")
 	fmt.Println()
-	fmt.Println("Run 'gotohp <command> --help' for more information on a command")
+	fmt.Printf("Run '%s <command> --help' for more information on a command\n", cliExecutableName)
 }
 
 func printCredentialsHelp() {
-	fmt.Println("Usage: gotohp creds <subcommand> [args]")
+	fmt.Printf("Usage: %s creds <subcommand> [args]\n", cliExecutableName)
 	fmt.Println()
 	fmt.Println("Subcommands:")
 	fmt.Println("  add <auth-string>       Add a new credential")
@@ -216,7 +218,7 @@ func handleCredentialsCommand(args []string) {
 	case "add":
 		if len(args) < 2 {
 			fmt.Println("Error: auth-string required")
-			fmt.Println("Usage: gotohp credentials add <auth-string>")
+			fmt.Printf("Usage: %s credentials add <auth-string>\n", cliExecutableName)
 			os.Exit(1)
 		}
 		authString := args[1]
@@ -230,7 +232,7 @@ func handleCredentialsCommand(args []string) {
 	case "remove", "rm":
 		if len(args) < 2 {
 			fmt.Println("Error: email required")
-			fmt.Println("Usage: gotohp credentials remove <email>")
+			fmt.Printf("Usage: %s credentials remove <email>\n", cliExecutableName)
 			os.Exit(1)
 		}
 		email := args[1]
@@ -269,7 +271,7 @@ func handleCredentialsCommand(args []string) {
 	case "set", "select":
 		if len(args) < 2 {
 			fmt.Println("Error: email required")
-			fmt.Println("Usage: gotohp creds set <email>")
+			fmt.Printf("Usage: %s creds set <email>\n", cliExecutableName)
 			os.Exit(1)
 		}
 		query := args[1]


### PR DESCRIPTION
## Summary
- Add standalone CLI release artifacts for macOS and Linux, matching the existing Windows CLI artifact.
- Build CLI artifacts with direct `go build -tags cli`, without Wails, frontend, WebKit, or GUI packaging.
- Move Wails event registration and adapter code behind `!cli` build tags so CLI builds do not import Wails.
- Add a Linux `gotohp-cli` deb package with no GTK/WebKit dependencies.
- Make standalone CLI help text use `gotohp-cli` and remove the GUI-launch usage line.
- Replace platform-specific README CLI sections with one universal `gotohp-cli` usage section.

Closes #35.

## Validation
- `go build ./...`
- Windows: `go build -tags cli -trimpath -buildvcs=false -ldflags="-w -s" -o bin\gotohp-cli-test.exe`; `bin\gotohp-cli-test.exe version`; `bin\gotohp-cli-test.exe help`; `bin\gotohp-cli-test.exe upload --help`
- Linux: `GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -tags cli -trimpath -buildvcs=false -ldflags="-w -s"`
- Linux host `x`: transferred binary to `/tmp/gotohp-cli-test/gotohp-cli`; verified matching SHA256/size; ran `version` and `help`; `ldd` reports `not a dynamic executable`
- macOS: `GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build -tags cli -trimpath -buildvcs=false -ldflags="-w -s"`
- macOS: `GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -tags cli -trimpath -buildvcs=false -ldflags="-w -s"`

No regression tests were run, per repo instruction.