### PR TITLE
Fix upload lifecycle on empty input

### DIFF
--- a/backend/upload.go
+++ b/backend/upload.go
@@ -117,10 +117,18 @@ func (m *UploadManager) Upload(app AppInterface, paths []string) {
 			Error:        err,
 			ErrorMessage: err.Error(),
 		})
+		app.EmitEvent("uploadStop", nil)
+		m.mu.Lock()
+		m.running = false
+		m.mu.Unlock()
 		return
 	}
 
 	if len(targetPaths) == 0 {
+		app.EmitEvent("uploadStop", nil)
+		m.mu.Lock()
+		m.running = false
+		m.mu.Unlock()
 		return
 	}
 


### PR DESCRIPTION
## Summary
- emit uploadStop when path filtering fails or finds no uploadable files
- reset the upload manager running flag on those early exits

## Testing
- Not run, per project instruction: no regression tests