### PR TITLE
Report API initialization failures for queued uploads

### DIFF
--- a/backend/upload.go
+++ b/backend/upload.go
@@ -130,6 +130,22 @@ func (m *UploadManager) Upload(app AppInterface, paths []string) {
 		TotalBytes: 0,
 	})
 
+	if _, err := NewApi(); err != nil {
+		for _, path := range targetPaths {
+			app.EmitEvent("FileStatus", FileUploadResult{
+				IsError:      true,
+				Error:        err,
+				ErrorMessage: err.Error(),
+				Path:         path,
+			})
+		}
+		app.EmitEvent("uploadStop", nil)
+		m.mu.Lock()
+		m.running = false
+		m.mu.Unlock()
+		return
+	}
+
 	// Calculate total bytes asynchronously and emit update when complete
 	go func() {
 		var totalBytes int64


### PR DESCRIPTION
## Summary
- validate API initialization before starting upload workers
- emit one failed FileStatus result per queued path when initialization fails
- stop the upload lifecycle after reporting the failures

## Testing
- Not run, per project instruction: no regression tests