### PR TITLE
Support paired Apple Live Photo uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Releases include a standalone CLI executable for command-line usage. Use the `go
 ```shell
 gotohp-cli upload /path/to/photos --recursive --threads 5
 gotohp-cli upload /path/to/photos --recursive --exclude @eaDir
+gotohp-cli upload IMG_0001.HEIC IMG_0001.MOV --pair-live-photos
 gotohp-cli creds list
 gotohp-cli creds add "androidId=..."
 gotohp-cli creds set user@gmail.com
@@ -32,13 +33,16 @@ gotohp-cli version
 
 **Available commands:**
 
-- `upload <filepath>` - Upload files or directories
+- `upload <path> [<path> ...]` - Upload one or more files or directories
   - `-r, --recursive` - Include subdirectories
   - `-t, --threads <n>` - Number of upload threads (default: 3)
   - `-f, --force` - Force upload even if file exists
   - `-d, --delete` - Delete from host after upload
   - `-df, --disable-filter` - Disable file type filtering
   - `--date-from-filename` - Set media date from filename (e.g. `20240709_182027.jpg`)
+  - `--pair-live-photos` - Pair Apple Live Photo components; incomplete pairs are skipped by default
+  - `--skip-incomplete-live-photos` - Skip metadata-confirmed Live Photo components whose match is absent
+  - `--upload-incomplete-live-photos` - Upload unmatched Live Photo components as ordinary single files
   - `-e, --exclude <pattern>` - Skip directories with this exact name during recursive upload (e.g. `@eaDir`)
   - `-a, --album <name>` - Add uploaded files to album (use `AUTO` for folder-based albums)
   - `-l, --log-level <level>` - Set log level: debug, info, warn, error (default: info)

--- a/backend/api.go
+++ b/backend/api.go
@@ -355,15 +355,15 @@ func (a *Api) FindRemoteMediaByHash(shaHash []byte) (string, error) {
 // attempt is 1-based (1 = first attempt, 2 = first retry, etc.)
 type UploadProgressCallback func(bytesUploaded, bytesTotal int64, attempt int)
 
-func (a *Api) UploadFile(ctx context.Context, filePath string, uploadToken string) (*generated.CommitToken, error) {
+func (a *Api) UploadFile(ctx context.Context, filePath string, uploadToken string) (ScottyFinalizeToken, error) {
 	return a.UploadFileWithProgress(ctx, filePath, uploadToken, nil)
 }
 
-func (a *Api) UploadFileWithProgress(ctx context.Context, filePath string, uploadToken string, onProgress UploadProgressCallback) (*generated.CommitToken, error) {
+func (a *Api) UploadFileWithProgress(ctx context.Context, filePath string, uploadToken string, onProgress UploadProgressCallback) (ScottyFinalizeToken, error) {
 	// Get file size first (needed for progress tracking)
 	fileInfo, err := os.Stat(filePath)
 	if err != nil {
-		return nil, fmt.Errorf("error getting file info: %w", err)
+		return ScottyFinalizeToken{}, fmt.Errorf("error getting file info: %w", err)
 	}
 	fileSize := fileInfo.Size()
 
@@ -376,7 +376,7 @@ func (a *Api) UploadFileWithProgress(ctx context.Context, filePath string, uploa
 
 		// Check context before each attempt
 		if ctx.Err() != nil {
-			return nil, ctx.Err()
+			return ScottyFinalizeToken{}, ctx.Err()
 		}
 
 		// Wait before retry (skip on first attempt)
@@ -384,7 +384,7 @@ func (a *Api) UploadFileWithProgress(ctx context.Context, filePath string, uploa
 			delay := CalculateBackoff(attempt-1, retryConfig)
 			select {
 			case <-ctx.Done():
-				return nil, ctx.Err()
+				return ScottyFinalizeToken{}, ctx.Err()
 			case <-time.After(delay):
 			}
 		}
@@ -397,7 +397,7 @@ func (a *Api) UploadFileWithProgress(ctx context.Context, filePath string, uploa
 		// Open file fresh for each attempt - this is the key to not loading into memory
 		file, err := os.Open(filePath)
 		if err != nil {
-			return nil, fmt.Errorf("error opening file: %w", err)
+			return ScottyFinalizeToken{}, fmt.Errorf("error opening file: %w", err)
 		}
 
 		// Wrap file in progress reader if callback provided
@@ -411,7 +411,7 @@ func (a *Api) UploadFileWithProgress(ctx context.Context, filePath string, uploa
 		result, err := a.doUploadRequest(ctx, uploadURL, reader)
 		closeErr := file.Close() // Close file after request completes (success or fail)
 		if err == nil && closeErr != nil {
-			return nil, fmt.Errorf("error closing file: %w", closeErr)
+			return ScottyFinalizeToken{}, fmt.Errorf("error closing file: %w", closeErr)
 		}
 
 		if err == nil {
@@ -422,18 +422,18 @@ func (a *Api) UploadFileWithProgress(ctx context.Context, filePath string, uploa
 
 		// Don't retry on context cancellation
 		if ctx.Err() != nil {
-			return nil, ctx.Err()
+			return ScottyFinalizeToken{}, ctx.Err()
 		}
 	}
 
-	return nil, fmt.Errorf("upload failed after %d attempts: %w", retryConfig.MaxRetries+1, lastErr)
+	return ScottyFinalizeToken{}, fmt.Errorf("upload failed after %d attempts: %w", retryConfig.MaxRetries+1, lastErr)
 }
 
 // doUploadRequest performs a single upload attempt
-func (a *Api) doUploadRequest(ctx context.Context, uploadURL string, reader io.Reader) (*generated.CommitToken, error) {
+func (a *Api) doUploadRequest(ctx context.Context, uploadURL string, reader io.Reader) (ScottyFinalizeToken, error) {
 	req, err := http.NewRequestWithContext(ctx, "PUT", uploadURL, reader)
 	if err != nil {
-		return nil, fmt.Errorf("error creating request: %w", err)
+		return ScottyFinalizeToken{}, fmt.Errorf("error creating request: %w", err)
 	}
 
 	// Use chunked transfer encoding (don't set ContentLength)
@@ -441,7 +441,7 @@ func (a *Api) doUploadRequest(ctx context.Context, uploadURL string, reader io.R
 
 	bearerToken, err := a.BearerToken()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get bearer token: %w", err)
+		return ScottyFinalizeToken{}, fmt.Errorf("failed to get bearer token: %w", err)
 	}
 
 	req.Header.Set("Accept-Encoding", "gzip")
@@ -451,27 +451,25 @@ func (a *Api) doUploadRequest(ctx context.Context, uploadURL string, reader io.R
 
 	resp, err := a.client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
+		return ScottyFinalizeToken{}, fmt.Errorf("request failed: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	// Check for non-success status codes (includes retryable 5xx/429 and non-retryable 4xx)
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		body, _ := ReadResponseBody(resp)
-		return nil, fmt.Errorf("request failed with status %d: %s", resp.StatusCode, string(body))
+		return ScottyFinalizeToken{}, fmt.Errorf("request failed with status %d: %s", resp.StatusCode, string(body))
 	}
 
 	bodyBytes, err := ReadResponseBody(resp)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read response body: %w", err)
+		return ScottyFinalizeToken{}, fmt.Errorf("failed to read response body: %w", err)
 	}
-
-	var pbResp generated.CommitToken
-	if err := proto.Unmarshal(bodyBytes, &pbResp); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal protobuf: %w", err)
+	token, err := ParseScottyFinalizeToken(bodyBytes)
+	if err != nil {
+		return ScottyFinalizeToken{}, fmt.Errorf("invalid upload finalize response: %w", err)
 	}
-
-	return &pbResp, nil
+	return token, nil
 }
 
 // CommitUpload commits the upload to Google Photos

--- a/backend/api.go
+++ b/backend/api.go
@@ -12,11 +12,17 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"app/generated"
 
+	"google.golang.org/protobuf/encoding/protowire"
 	"google.golang.org/protobuf/proto"
 )
+
+// PhotosCreateMediaItems is the shared commit RPC observed for both ordinary
+// images and linked Live Photos; pairing changes the request body, not the RPC.
+const photosCreateMediaItemsEndpoint = "https://photosdata-pa.googleapis.com/6439526531001121323/16538846908252377752"
 
 type Api struct {
 	androidAPIVersion int64
@@ -28,6 +34,8 @@ type Api struct {
 	authData          string
 	client            *http.Client
 	authResponseCache map[string]string
+	commitEndpoint    string
+	commitRetryConfig *RetryConfig
 }
 
 type AuthResponse struct {
@@ -525,26 +533,44 @@ func (a *Api) CommitUpload(
 		return "", fmt.Errorf("failed to marshal protobuf: %w", err)
 	}
 
+	return a.commitSerialized(serializedData)
+}
+
+func (a *Api) CommitLivePhoto(input LivePhotoCreateRequest) (string, error) {
+	serializedData, err := BuildLivePhotoCreateMediaItemsRequest(input)
+	if err != nil {
+		return "", fmt.Errorf("build Live Photo create request: %w", err)
+	}
+	return a.commitSerialized(serializedData)
+}
+
+func (a *Api) commitSerialized(serializedData []byte) (string, error) {
 	retryConfig := DefaultRetryConfig()
+	if a.commitRetryConfig != nil {
+		retryConfig = *a.commitRetryConfig
+	}
 	var lastErr error
 	for attempt := 0; attempt <= retryConfig.MaxRetries; attempt++ {
 		if attempt > 0 {
 			delay := CalculateBackoff(attempt-1, retryConfig)
 			time.Sleep(delay)
 		}
-		mediaKey, err := a.doCommitRequest(serializedData)
+		mediaKey, retryable, err := a.doCommitRequest(serializedData)
 		if err == nil {
 			return mediaKey, nil
 		}
 		lastErr = err
+		if !retryable {
+			return "", fmt.Errorf("commit failed after %d attempt(s): %w", attempt+1, lastErr)
+		}
 	}
 	return "", fmt.Errorf("commit failed after %d attempts: %w", retryConfig.MaxRetries+1, lastErr)
 }
 
-func (a *Api) doCommitRequest(serializedData []byte) (string, error) {
+func (a *Api) doCommitRequest(serializedData []byte) (mediaKey string, retryable bool, err error) {
 	bearerToken, err := a.BearerToken()
 	if err != nil {
-		return "", fmt.Errorf("failed to get bearer token: %w", err)
+		return "", true, fmt.Errorf("failed to get bearer token: %w", err)
 	}
 
 	headers := map[string]string{
@@ -557,11 +583,13 @@ func (a *Api) doCommitRequest(serializedData []byte) (string, error) {
 		"x-goog-ext-174067345-bin": "CgIIAg==",
 	}
 
-	req, err := http.NewRequest("POST",
-		"https://photosdata-pa.googleapis.com/6439526531001121323/16538846908252377752",
-		bytes.NewReader(serializedData))
+	endpoint := a.commitEndpoint
+	if endpoint == "" {
+		endpoint = photosCreateMediaItemsEndpoint
+	}
+	req, err := http.NewRequest("POST", endpoint, bytes.NewReader(serializedData))
 	if err != nil {
-		return "", fmt.Errorf("failed to create request: %w", err)
+		return "", false, fmt.Errorf("failed to create request: %w", err)
 	}
 	for k, v := range headers {
 		req.Header.Set(k, v)
@@ -569,33 +597,75 @@ func (a *Api) doCommitRequest(serializedData []byte) (string, error) {
 
 	resp, err := a.client.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("request failed: %w", err)
+		return "", true, fmt.Errorf("request failed: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		body, _ := ReadResponseBody(resp)
-		return "", fmt.Errorf("request failed with status %d: %s", resp.StatusCode, string(body))
+		return "", ShouldRetry(resp, nil), fmt.Errorf("request failed with status %d: %s", resp.StatusCode, string(body))
 	}
 
 	bodyBytes, err := ReadResponseBody(resp)
 	if err != nil {
-		return "", fmt.Errorf("failed to read response body: %w", err)
+		return "", false, fmt.Errorf("failed to read accepted response body: %w", err)
 	}
 
-	var pbResp generated.CommitUploadResponse
-	if err := proto.Unmarshal(bodyBytes, &pbResp); err != nil {
-		return "", fmt.Errorf("failed to unmarshal protobuf: %w", err)
+	// HTTP success may mean the media item already exists even when this partial
+	// response parser cannot validate it. Do not retry and risk a duplicate commit.
+	mediaKey, err = extractCommitMediaKey(bodyBytes)
+	if err != nil {
+		return "", false, fmt.Errorf("failed to parse accepted response: %w", err)
 	}
+	return mediaKey, false, nil
+}
 
-	if pbResp.GetField1() == nil || pbResp.GetField1().GetField3() == nil {
-		return "", fmt.Errorf("upload rejected by API: invalid response structure")
+// extractCommitMediaKey reads only the stable result-item path from the private
+// create-media response. The rest of Google's response is intentionally opaque;
+// decoding it with the partial recovered schema rejects valid Live Photo results.
+func extractCommitMediaKey(response []byte) (string, error) {
+	responseItem, err := consumeBytesField(response, 1)
+	if err != nil {
+		return "", fmt.Errorf("read create-media response item: %w", err)
 	}
-	mediaKey := pbResp.GetField1().GetField3().GetMediaKey()
-	if mediaKey == "" {
-		return "", fmt.Errorf("upload rejected by API: no media key returned")
+	resultItem, err := consumeBytesField(responseItem, 3)
+	if err != nil {
+		return "", fmt.Errorf("read create-media result item: %w", err)
 	}
-	return mediaKey, nil
+	mediaKeyBytes, err := consumeBytesField(resultItem, 1)
+	if err != nil {
+		return "", fmt.Errorf("read create-media media key: %w", err)
+	}
+	if len(mediaKeyBytes) == 0 || !utf8.Valid(mediaKeyBytes) {
+		return "", fmt.Errorf("upload rejected by API: media key is empty or invalid UTF-8")
+	}
+	return string(mediaKeyBytes), nil
+}
+
+func consumeBytesField(message []byte, target protowire.Number) ([]byte, error) {
+	for len(message) > 0 {
+		number, wireType, tagLength := protowire.ConsumeTag(message)
+		if tagLength < 0 {
+			return nil, protowire.ParseError(tagLength)
+		}
+		message = message[tagLength:]
+		if number == target {
+			if wireType != protowire.BytesType {
+				return nil, fmt.Errorf("field %d has wire type %d, want bytes", target, wireType)
+			}
+			value, valueLength := protowire.ConsumeBytes(message)
+			if valueLength < 0 {
+				return nil, protowire.ParseError(valueLength)
+			}
+			return value, nil
+		}
+		valueLength := protowire.ConsumeFieldValue(number, wireType, message)
+		if valueLength < 0 {
+			return nil, protowire.ParseError(valueLength)
+		}
+		message = message[valueLength:]
+	}
+	return nil, fmt.Errorf("field %d is missing", target)
 }
 
 // CreateAlbum creates a new album with the given name and initial media items.

--- a/backend/configmanager.go
+++ b/backend/configmanager.go
@@ -28,6 +28,8 @@ type Config struct {
 	Saver                         bool     `json:"saver" koanf:"saver"`
 	Recursive                     bool     `json:"recursive" koanf:"recursive"`
 	ForceUpload                   bool     `json:"forceUpload" koanf:"force_upload"`
+	PairLivePhotos                bool     `json:"pairLivePhotos" koanf:"pair_live_photos"`
+	SkipIncompleteLivePhotos      bool     `json:"skipIncompleteLivePhotos" koanf:"skip_incomplete_live_photos"`
 	UploadThreads                 int      `json:"uploadThreads" koanf:"upload_threads"`
 	DeleteFromHost                bool     `json:"deleteFromHost" koanf:"delete_from_host"`
 	DisableUnsupportedFilesFilter bool     `json:"disableUnsupportedFilesFilter" koanf:"disable_unsupported_files_filter"`
@@ -82,6 +84,16 @@ func (g *ConfigManager) SetRecursive(recursive bool) {
 
 func (g *ConfigManager) SetForceUpload(forceUpload bool) {
 	AppConfig.ForceUpload = forceUpload
+	_ = saveAppConfig()
+}
+
+func (g *ConfigManager) SetPairLivePhotos(pairLivePhotos bool) {
+	AppConfig.PairLivePhotos = pairLivePhotos
+	_ = saveAppConfig()
+}
+
+func (g *ConfigManager) SetSkipIncompleteLivePhotos(skipIncompleteLivePhotos bool) {
+	AppConfig.SkipIncompleteLivePhotos = skipIncompleteLivePhotos
 	_ = saveAppConfig()
 }
 

--- a/backend/configmanager.go
+++ b/backend/configmanager.go
@@ -47,7 +47,8 @@ var (
 	UploadRunning bool = false
 	ConfigPath    string
 	DefaultConfig = Config{
-		UploadThreads: 3,
+		SkipIncompleteLivePhotos: true,
+		UploadThreads:            3,
 	}
 )
 

--- a/backend/create_media_items.go
+++ b/backend/create_media_items.go
@@ -1,0 +1,135 @@
+package backend
+
+import (
+	"crypto/sha1"
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"time"
+
+	"google.golang.org/protobuf/encoding/protowire"
+)
+
+// This opaque result-item mask occupied top-level field 5 and was identical in
+// all 17 accepted official-client requests across the scoped captures.
+const livePhotoResultItemMaskBase64 = "CnsKAggBEAEaAggBIgIIASoQCgIIARICCAEaAggBIgIIATICCAGCAQIIAYoBAggBmgECCAGiAQIIAaoBCggBKgIgATICCAHKAQIIAfIBBggBEgIIAfoBAggBggICCAGKAgQKAggBkgIGCAESAggBogICCAGqAgC6AgDCAgAQASpiCAESKggBEhIIARoGCAESAggBIgQIASIAKAEiBggBEgIQASoGCAESAggBMAE4ARoWCAESDAgBGgIIASICCAEoARoCCAEwASIKCAESBggBEgIIASoOCgQIATABEgYIARICCAE6AggBQgIIAUoKCAESAggBGgISAFoSEgIIARoCCAEiCAgBEgQIARACYgIIAXISEgIIARoCCAEiCAgBEgQIARACeggKAggBIgIIAYoBBAoCCAGSAQQIARABqgECCgA="
+
+type UploadDeviceInfo struct {
+	Model             string
+	Make              string
+	AndroidAPIVersion int64
+}
+
+type LivePhotoCreateRequest struct {
+	PhotoToken       ScottyFinalizeToken
+	VideoToken       ScottyFinalizeToken
+	FileName         string
+	PhotoSHA1        []byte
+	VideoSHA1        []byte
+	CreatedAt        time.Time
+	ModifiedAt       time.Time
+	StoragePolicy    int64
+	UploadQuality    int64
+	UploadDeviceInfo UploadDeviceInfo
+}
+
+type LivePhotoCommitPolicy struct {
+	StoragePolicy    int64
+	UploadQuality    int64
+	UploadDeviceInfo UploadDeviceInfo
+}
+
+func buildLivePhotoCommitPolicy(api *Api, config Config) LivePhotoCommitPolicy {
+	storagePolicy := int64(3)
+	model := api.model
+	if config.Saver {
+		storagePolicy = 1
+		model = "Pixel 2"
+	}
+	// Use Quota selects the current quota-counting device regardless of quality.
+	if config.UseQuota {
+		model = "Pixel 8"
+	}
+	return LivePhotoCommitPolicy{
+		StoragePolicy: storagePolicy,
+		UploadQuality: 1,
+		UploadDeviceInfo: UploadDeviceInfo{
+			Model:             model,
+			Make:              api.make,
+			AndroidAPIVersion: api.androidAPIVersion,
+		},
+	}
+}
+
+func BuildLivePhotoCreateMediaItemsRequest(input LivePhotoCreateRequest) ([]byte, error) {
+	if _, err := ParseScottyFinalizeToken(input.PhotoToken.Raw); err != nil {
+		return nil, fmt.Errorf("invalid photo finalize token: %w", err)
+	}
+	if _, err := ParseScottyFinalizeToken(input.VideoToken.Raw); err != nil {
+		return nil, fmt.Errorf("invalid video finalize token: %w", err)
+	}
+	if strings.TrimSpace(input.FileName) == "" {
+		return nil, fmt.Errorf("photo filename is required")
+	}
+	if len(input.PhotoSHA1) != sha1.Size || len(input.VideoSHA1) != sha1.Size {
+		return nil, fmt.Errorf("photo and video SHA-1 values must each contain %d bytes", sha1.Size)
+	}
+	if input.CreatedAt.IsZero() || input.ModifiedAt.IsZero() {
+		return nil, fmt.Errorf("photo creation and modification times are required")
+	}
+	if input.StoragePolicy <= 0 || input.UploadQuality <= 0 {
+		return nil, fmt.Errorf("storage policy and upload quality must be positive")
+	}
+	if input.UploadDeviceInfo.Model == "" || input.UploadDeviceInfo.Make == "" || input.UploadDeviceInfo.AndroidAPIVersion <= 0 {
+		return nil, fmt.Errorf("complete Android upload device information is required")
+	}
+
+	resultItemMask, err := base64.StdEncoding.DecodeString(livePhotoResultItemMaskBase64)
+	if err != nil {
+		return nil, fmt.Errorf("decode result item mask: %w", err)
+	}
+
+	// Emit the official-client invariant shape directly so Scotty tokens remain
+	// byte-identical. Blueprint fields are uploadToken=1, fileName=2,
+	// sourceSha1=3, createTime=5, modTime=6, storagePolicy=7,
+	// uploadQuality=10, and livePhotoInfo=24. LivePhotoInfo contains
+	// videoUploadToken=1 and videoSourceSha1=2. Client capabilities (top-level 3)
+	// and videoCrc32C (24.3) are schema fields but were absent from every accepted
+	// scoped request; passive captures do not prove the server's absolute minimum.
+
+	liveInfo := appendBytesWireField(nil, 1, input.VideoToken.Raw)
+	liveInfo = appendBytesWireField(liveInfo, 2, input.VideoSHA1)
+
+	blueprint := appendBytesWireField(nil, 1, input.PhotoToken.Raw)
+	blueprint = appendBytesWireField(blueprint, 2, []byte(input.FileName))
+	blueprint = appendBytesWireField(blueprint, 3, input.PhotoSHA1)
+	blueprint = appendBytesWireField(blueprint, 5, marshalUploadTimestamp(input.CreatedAt))
+	blueprint = appendBytesWireField(blueprint, 6, marshalUploadTimestamp(input.ModifiedAt))
+	blueprint = appendVarintWireField(blueprint, 7, uint64(input.StoragePolicy))
+	blueprint = appendVarintWireField(blueprint, 10, uint64(input.UploadQuality))
+	blueprint = appendBytesWireField(blueprint, 24, liveInfo)
+
+	device := appendBytesWireField(nil, 3, []byte(input.UploadDeviceInfo.Model))
+	device = appendBytesWireField(device, 4, []byte(input.UploadDeviceInfo.Make))
+	device = appendVarintWireField(device, 5, uint64(input.UploadDeviceInfo.AndroidAPIVersion))
+
+	request := appendBytesWireField(nil, 1, blueprint)
+	request = appendBytesWireField(request, 2, device)
+	request = appendBytesWireField(request, 5, resultItemMask)
+	return request, nil
+}
+
+func marshalUploadTimestamp(value time.Time) []byte {
+	timestamp := appendVarintWireField(nil, 1, uint64(value.Unix()))
+	return appendVarintWireField(timestamp, 2, uint64(value.Nanosecond()))
+}
+
+func appendBytesWireField(message []byte, number protowire.Number, value []byte) []byte {
+	message = protowire.AppendTag(message, number, protowire.BytesType)
+	return protowire.AppendBytes(message, value)
+}
+
+func appendVarintWireField(message []byte, number protowire.Number, value uint64) []byte {
+	message = protowire.AppendTag(message, number, protowire.VarintType)
+	return protowire.AppendVarint(message, value)
+}

--- a/backend/livephoto.go
+++ b/backend/livephoto.go
@@ -1,0 +1,242 @@
+package backend
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+type UploadWorkKind string
+
+const (
+	UploadWorkSingle    UploadWorkKind = "single"
+	UploadWorkLivePhoto UploadWorkKind = "live-photo"
+)
+
+type SingleMedia struct {
+	Path string
+}
+
+type LivePhotoPair struct {
+	ContentIdentifier string
+	PhotoPath         string
+	VideoPath         string
+}
+
+type UploadWorkItem struct {
+	Kind      UploadWorkKind
+	Single    *SingleMedia
+	LivePhoto *LivePhotoPair
+}
+
+type PreflightWarning struct {
+	Paths   []string `json:"Paths"`
+	Code    string   `json:"Code"`
+	Message string   `json:"Message"`
+}
+
+type LivePhotoClassificationOptions struct {
+	Enabled        bool
+	SkipIncomplete bool
+}
+
+type LivePhotoMetadataReader interface {
+	PhotoContentIdentifier(path string) (string, error)
+	VideoLivePhotoMetadata(path string) (LivePhotoMetadata, error)
+}
+
+type fileLivePhotoMetadataReader struct{}
+
+func (fileLivePhotoMetadataReader) PhotoContentIdentifier(path string) (string, error) {
+	return ReadPhotoContentIdentifier(path)
+}
+
+func (fileLivePhotoMetadataReader) VideoLivePhotoMetadata(path string) (LivePhotoMetadata, error) {
+	return ReadVideoLivePhotoMetadata(path)
+}
+
+type indexedLivePhotoMedia struct {
+	path  string
+	index int
+}
+
+type livePhotoCandidates struct {
+	photos []indexedLivePhotoMedia
+	videos []indexedLivePhotoMedia
+}
+
+// ClassifyUploadWork pairs files by their embedded Apple content identifier.
+// Filenames are deliberately ignored because iOS exports can rename either half.
+func ClassifyUploadWork(paths []string, options LivePhotoClassificationOptions, reader LivePhotoMetadataReader) ([]UploadWorkItem, []PreflightWarning) {
+	if !options.Enabled {
+		return singleUploadWork(paths), nil
+	}
+	if reader == nil {
+		reader = fileLivePhotoMetadataReader{}
+	}
+
+	candidatesByIdentifier := make(map[string]*livePhotoCandidates)
+	warnings := make([]PreflightWarning, 0)
+	for index, path := range paths {
+		switch livePhotoCandidateType(path) {
+		case "photo":
+			identifier, err := reader.PhotoContentIdentifier(path)
+			if errors.Is(err, ErrContentIdentifierMissing) {
+				continue
+			}
+			if err != nil {
+				warnings = append(warnings, metadataReadWarning(path, err))
+				continue
+			}
+			candidates := candidatesForIdentifier(candidatesByIdentifier, identifier)
+			candidates.photos = append(candidates.photos, indexedLivePhotoMedia{path: path, index: index})
+		case "video":
+			metadata, err := reader.VideoLivePhotoMetadata(path)
+			if errors.Is(err, ErrContentIdentifierMissing) {
+				continue
+			}
+			if err != nil {
+				warnings = append(warnings, metadataReadWarning(path, err))
+				continue
+			}
+			if !metadata.HasStillImageTime {
+				warnings = append(warnings, PreflightWarning{
+					Paths:   []string{path},
+					Code:    "missing-still-image-time",
+					Message: "video has a Live Photo content identifier but no still-image-time marker",
+				})
+				continue
+			}
+			candidates := candidatesForIdentifier(candidatesByIdentifier, metadata.ContentIdentifier)
+			candidates.videos = append(candidates.videos, indexedLivePhotoMedia{path: path, index: index})
+		}
+	}
+
+	pairsByIndex := make(map[int]LivePhotoPair)
+	consumed := make(map[int]bool)
+	identifiers := sortedLivePhotoIdentifiers(candidatesByIdentifier)
+	for _, identifier := range identifiers {
+		candidates := candidatesByIdentifier[identifier]
+		if len(candidates.photos) == 1 && len(candidates.videos) == 1 {
+			photo := candidates.photos[0]
+			video := candidates.videos[0]
+			pairIndex := min(photo.index, video.index)
+			pairsByIndex[pairIndex] = LivePhotoPair{
+				ContentIdentifier: identifier,
+				PhotoPath:         photo.path,
+				VideoPath:         video.path,
+			}
+			consumed[photo.index] = true
+			consumed[video.index] = true
+			continue
+		}
+		if len(candidates.photos) > 1 || len(candidates.videos) > 1 {
+			ambiguousPaths := candidatePaths(candidates)
+			warnings = append(warnings, PreflightWarning{
+				Paths:   ambiguousPaths,
+				Code:    "ambiguous-identifier",
+				Message: "multiple photo or video candidates share one Live Photo identifier",
+			})
+			continue
+		}
+		if options.SkipIncomplete {
+			orphanPaths := candidatePaths(candidates)
+			for _, photo := range candidates.photos {
+				consumed[photo.index] = true
+			}
+			for _, video := range candidates.videos {
+				consumed[video.index] = true
+			}
+			warnings = append(warnings, PreflightWarning{
+				Paths:   orphanPaths,
+				Code:    "incomplete-live-photo-skipped",
+				Message: "Skipped an incomplete Live Photo because its matching file is not in this queue. You can disable this check in Settings.",
+			})
+		}
+	}
+
+	work := make([]UploadWorkItem, 0, len(paths))
+	for index, path := range paths {
+		if pair, ok := pairsByIndex[index]; ok {
+			pair := pair
+			work = append(work, UploadWorkItem{Kind: UploadWorkLivePhoto, LivePhoto: &pair})
+			continue
+		}
+		if consumed[index] {
+			continue
+		}
+		work = append(work, UploadWorkItem{Kind: UploadWorkSingle, Single: &SingleMedia{Path: path}})
+	}
+	return work, warnings
+}
+
+func sortedLivePhotoIdentifiers(candidatesByIdentifier map[string]*livePhotoCandidates) []string {
+	identifiers := make([]string, 0, len(candidatesByIdentifier))
+	for identifier := range candidatesByIdentifier {
+		identifiers = append(identifiers, identifier)
+	}
+	sort.Slice(identifiers, func(left, right int) bool {
+		return candidateFirstIndex(candidatesByIdentifier[identifiers[left]]) < candidateFirstIndex(candidatesByIdentifier[identifiers[right]])
+	})
+	return identifiers
+}
+
+func candidateFirstIndex(candidates *livePhotoCandidates) int {
+	first := int(^uint(0) >> 1)
+	for _, photo := range candidates.photos {
+		first = min(first, photo.index)
+	}
+	for _, video := range candidates.videos {
+		first = min(first, video.index)
+	}
+	return first
+}
+
+func singleUploadWork(paths []string) []UploadWorkItem {
+	work := make([]UploadWorkItem, 0, len(paths))
+	for _, path := range paths {
+		work = append(work, UploadWorkItem{Kind: UploadWorkSingle, Single: &SingleMedia{Path: path}})
+	}
+	return work
+}
+
+func livePhotoCandidateType(path string) string {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".heic", ".heif", ".jpg", ".jpeg":
+		return "photo"
+	case ".mov":
+		return "video"
+	default:
+		return ""
+	}
+}
+
+func candidatesForIdentifier(candidatesByIdentifier map[string]*livePhotoCandidates, identifier string) *livePhotoCandidates {
+	candidates := candidatesByIdentifier[identifier]
+	if candidates == nil {
+		candidates = &livePhotoCandidates{}
+		candidatesByIdentifier[identifier] = candidates
+	}
+	return candidates
+}
+
+func metadataReadWarning(path string, err error) PreflightWarning {
+	return PreflightWarning{
+		Paths:   []string{path},
+		Code:    "metadata-read-failed",
+		Message: fmt.Sprintf("could not read Live Photo metadata: %v", err),
+	}
+}
+
+func candidatePaths(candidates *livePhotoCandidates) []string {
+	paths := make([]string, 0, len(candidates.photos)+len(candidates.videos))
+	for _, photo := range candidates.photos {
+		paths = append(paths, photo.path)
+	}
+	for _, video := range candidates.videos {
+		paths = append(paths, video.path)
+	}
+	return paths
+}

--- a/backend/livephoto_metadata.go
+++ b/backend/livephoto_metadata.go
@@ -1,0 +1,553 @@
+package backend
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+const (
+	appleMakerNoteHeader = "Apple iOS\x00"
+	maxMakerNoteScanSize = 64 << 20
+	maxContentIdentifier = 256
+)
+
+var ErrContentIdentifierMissing = errors.New("live photo content identifier is missing")
+
+type LivePhotoMetadata struct {
+	ContentIdentifier string
+	HasStillImageTime bool
+}
+
+func ReadPhotoContentIdentifier(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("open photo metadata: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	info, err := file.Stat()
+	if err != nil {
+		return "", fmt.Errorf("stat photo metadata: %w", err)
+	}
+	return readPhotoContentIdentifier(file, info.Size())
+}
+
+func ReadVideoLivePhotoMetadata(path string) (LivePhotoMetadata, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return LivePhotoMetadata{}, fmt.Errorf("open video metadata: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	info, err := file.Stat()
+	if err != nil {
+		return LivePhotoMetadata{}, fmt.Errorf("stat video metadata: %w", err)
+	}
+	return readVideoLivePhotoMetadata(file, info.Size())
+}
+
+func readPhotoContentIdentifier(reader io.ReaderAt, size int64) (string, error) {
+	if size <= 0 {
+		return "", ErrContentIdentifierMissing
+	}
+	scanSize := min(size, maxMakerNoteScanSize)
+	data := make([]byte, scanSize)
+	if _, err := reader.ReadAt(data, 0); err != nil && !errors.Is(err, io.EOF) {
+		return "", fmt.Errorf("read photo metadata: %w", err)
+	}
+
+	marker := []byte(appleMakerNoteHeader)
+	var parseErr error
+	for searchFrom := 0; searchFrom < len(data); {
+		relativeOffset := bytes.Index(data[searchFrom:], marker)
+		if relativeOffset < 0 {
+			break
+		}
+		markerOffset := searchFrom + relativeOffset
+		identifier, err := parseAppleMakerNoteIdentifier(data[markerOffset:])
+		if err == nil {
+			return identifier, nil
+		}
+		parseErr = err
+		searchFrom = markerOffset + len(marker)
+	}
+	if parseErr != nil {
+		return "", parseErr
+	}
+	return "", ErrContentIdentifierMissing
+}
+
+func parseAppleMakerNoteIdentifier(data []byte) (string, error) {
+	if len(data) < 16 || string(data[:len(appleMakerNoteHeader)]) != appleMakerNoteHeader {
+		return "", fmt.Errorf("invalid Apple Maker Note header")
+	}
+
+	var order binary.ByteOrder
+	switch string(data[12:14]) {
+	case "MM":
+		order = binary.BigEndian
+	case "II":
+		order = binary.LittleEndian
+	default:
+		return "", fmt.Errorf("invalid Apple Maker Note byte order")
+	}
+
+	entryCount := int(order.Uint16(data[14:16]))
+	entriesEnd := 16 + entryCount*12
+	if entryCount <= 0 || entriesEnd > len(data) {
+		return "", fmt.Errorf("invalid Apple Maker Note entry table")
+	}
+
+	// Apple Maker Note tag 17 is the asset content identifier shared with the
+	// paired QuickTime file; it is the pairing key rather than the filenames.
+	for index := 0; index < entryCount; index++ {
+		entry := data[16+index*12 : 16+(index+1)*12]
+		if order.Uint16(entry[0:2]) != 17 {
+			continue
+		}
+		if order.Uint16(entry[2:4]) != 2 {
+			return "", fmt.Errorf("Apple content identifier has unexpected type")
+		}
+		valueLength := uint64(order.Uint32(entry[4:8]))
+		if valueLength == 0 || valueLength > maxContentIdentifier {
+			return "", fmt.Errorf("Apple content identifier has invalid length")
+		}
+
+		var value []byte
+		if valueLength <= 4 {
+			value = entry[8 : 8+valueLength]
+		} else {
+			valueOffset := uint64(order.Uint32(entry[8:12]))
+			if valueOffset > uint64(len(data)) || valueLength > uint64(len(data))-valueOffset {
+				return "", fmt.Errorf("Apple content identifier points outside Maker Note")
+			}
+			value = data[valueOffset : valueOffset+valueLength]
+		}
+
+		identifier := strings.Trim(string(value), "\x00 \t\r\n")
+		if !isCanonicalUUID(identifier) {
+			return "", fmt.Errorf("Apple content identifier is not a canonical UUID")
+		}
+		return identifier, nil
+	}
+	return "", ErrContentIdentifierMissing
+}
+
+func isCanonicalUUID(value string) bool {
+	if len(value) != 36 {
+		return false
+	}
+	for index, character := range value {
+		switch index {
+		case 8, 13, 18, 23:
+			if character != '-' {
+				return false
+			}
+		default:
+			if !((character >= '0' && character <= '9') ||
+				(character >= 'a' && character <= 'f') ||
+				(character >= 'A' && character <= 'F')) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+type mp4Box struct {
+	typ          [4]byte
+	payloadStart int64
+	end          int64
+}
+
+func readVideoLivePhotoMetadata(reader io.ReaderAt, size int64) (LivePhotoMetadata, error) {
+	if size < 8 {
+		return LivePhotoMetadata{}, fmt.Errorf("invalid QuickTime file size")
+	}
+
+	metadata := LivePhotoMetadata{}
+	err := walkMP4Boxes(reader, 0, size, func(box mp4Box) error {
+		switch string(box.typ[:]) {
+		case "meta":
+			identifier, found, err := readQuickTimeContentIdentifier(reader, box)
+			if err != nil {
+				return err
+			}
+			if found {
+				metadata.ContentIdentifier = identifier
+			}
+		case "stbl":
+			hasStillImageTime, err := readStillImageTimeTrack(reader, box)
+			if err != nil {
+				return err
+			}
+			metadata.HasStillImageTime = metadata.HasStillImageTime || hasStillImageTime
+		}
+		return nil
+	})
+	if err != nil {
+		return LivePhotoMetadata{}, err
+	}
+	if metadata.ContentIdentifier == "" {
+		return metadata, ErrContentIdentifierMissing
+	}
+	return metadata, nil
+}
+
+func walkMP4Boxes(reader io.ReaderAt, start, end int64, visit func(mp4Box) error) error {
+	for offset := start; offset < end; {
+		box, err := readMP4Box(reader, offset, end)
+		if err != nil {
+			return err
+		}
+		if err := visit(box); err != nil {
+			return err
+		}
+		if isMP4Container(box.typ) {
+			childStart := box.payloadStart
+			if string(box.typ[:]) == "meta" {
+				var err error
+				childStart, err = quickTimeMetaChildrenStart(reader, box)
+				if err != nil {
+					return err
+				}
+			}
+			if childStart > box.end {
+				return fmt.Errorf("invalid %s container", string(box.typ[:]))
+			}
+			if err := walkMP4Boxes(reader, childStart, box.end, visit); err != nil {
+				return err
+			}
+		}
+		offset = box.end
+	}
+	return nil
+}
+
+// QuickTime permits a headerless meta atom, while ISO BMFF meta boxes begin
+// with four version/flags bytes. Detect the form from the first child header.
+func quickTimeMetaChildrenStart(reader io.ReaderAt, box mp4Box) (int64, error) {
+	payloadSize := box.end - box.payloadStart
+	if payloadSize < 8 {
+		return 0, fmt.Errorf("truncated QuickTime meta box")
+	}
+	header := make([]byte, 8)
+	if _, err := reader.ReadAt(header, box.payloadStart); err != nil {
+		return 0, fmt.Errorf("read QuickTime meta box: %w", err)
+	}
+	firstChildSize := int64(binary.BigEndian.Uint32(header[:4]))
+	if firstChildSize >= 8 && firstChildSize <= payloadSize {
+		return box.payloadStart, nil
+	}
+	if payloadSize < 12 {
+		return 0, fmt.Errorf("truncated ISO meta box")
+	}
+	return box.payloadStart + 4, nil
+}
+
+func readMP4Box(reader io.ReaderAt, offset, parentEnd int64) (mp4Box, error) {
+	header := make([]byte, 16)
+	if offset < 0 || parentEnd-offset < 8 {
+		return mp4Box{}, fmt.Errorf("truncated QuickTime box header at %d", offset)
+	}
+	if _, err := reader.ReadAt(header[:8], offset); err != nil {
+		return mp4Box{}, fmt.Errorf("read QuickTime box header at %d: %w", offset, err)
+	}
+
+	boxSize := int64(binary.BigEndian.Uint32(header[:4]))
+	headerSize := int64(8)
+	if boxSize == 1 {
+		if parentEnd-offset < 16 {
+			return mp4Box{}, fmt.Errorf("truncated extended QuickTime box header at %d", offset)
+		}
+		if _, err := reader.ReadAt(header[8:16], offset+8); err != nil {
+			return mp4Box{}, fmt.Errorf("read extended QuickTime box header at %d: %w", offset, err)
+		}
+		boxSize = int64(binary.BigEndian.Uint64(header[8:16]))
+		headerSize = 16
+	} else if boxSize == 0 {
+		boxSize = parentEnd - offset
+	}
+	if boxSize < headerSize || boxSize > parentEnd-offset {
+		return mp4Box{}, fmt.Errorf("invalid QuickTime box size at %d", offset)
+	}
+
+	var boxType [4]byte
+	copy(boxType[:], header[4:8])
+	return mp4Box{typ: boxType, payloadStart: offset + headerSize, end: offset + boxSize}, nil
+}
+
+func isMP4Container(boxType [4]byte) bool {
+	switch string(boxType[:]) {
+	case "moov", "trak", "mdia", "minf", "stbl", "udta", "meta":
+		return true
+	default:
+		return false
+	}
+}
+
+func readQuickTimeContentIdentifier(reader io.ReaderAt, meta mp4Box) (string, bool, error) {
+	childrenStart, err := quickTimeMetaChildrenStart(reader, meta)
+	if err != nil {
+		return "", false, err
+	}
+	children, err := readDirectMP4Boxes(reader, childrenStart, meta.end)
+	if err != nil {
+		return "", false, err
+	}
+	var keysBox, itemListBox *mp4Box
+	for index := range children {
+		switch string(children[index].typ[:]) {
+		case "keys":
+			keysBox = &children[index]
+		case "ilst":
+			itemListBox = &children[index]
+		}
+	}
+	if keysBox == nil || itemListBox == nil {
+		return "", false, nil
+	}
+
+	keys, err := readQuickTimeKeys(reader, *keysBox)
+	if err != nil {
+		return "", false, err
+	}
+	contentIndex := 0
+	for index, key := range keys {
+		if key == "com.apple.quicktime.content.identifier" {
+			contentIndex = index + 1
+			break
+		}
+	}
+	if contentIndex == 0 {
+		return "", false, nil
+	}
+
+	identifier, found, err := readQuickTimeItemValue(reader, *itemListBox, uint32(contentIndex))
+	if err != nil || !found {
+		return "", found, err
+	}
+	identifier = strings.Trim(identifier, "\x00 \t\r\n")
+	if !isCanonicalUUID(identifier) {
+		return "", false, fmt.Errorf("QuickTime content identifier is not a canonical UUID")
+	}
+	return identifier, true, nil
+}
+
+func readDirectMP4Boxes(reader io.ReaderAt, start, end int64) ([]mp4Box, error) {
+	var boxes []mp4Box
+	for offset := start; offset < end; {
+		box, err := readMP4Box(reader, offset, end)
+		if err != nil {
+			return nil, err
+		}
+		boxes = append(boxes, box)
+		offset = box.end
+	}
+	return boxes, nil
+}
+
+func readQuickTimeKeys(reader io.ReaderAt, box mp4Box) ([]string, error) {
+	payload, err := readBoxPayload(reader, box, 4<<20)
+	if err != nil {
+		return nil, err
+	}
+	if len(payload) < 8 {
+		return nil, fmt.Errorf("truncated QuickTime keys box")
+	}
+	entryCount := int(binary.BigEndian.Uint32(payload[4:8]))
+	offset := 8
+	keys := make([]string, 0, entryCount)
+	for index := 0; index < entryCount; index++ {
+		if len(payload)-offset < 8 {
+			return nil, fmt.Errorf("truncated QuickTime metadata key")
+		}
+		entrySize := int(binary.BigEndian.Uint32(payload[offset : offset+4]))
+		if entrySize < 8 || entrySize > len(payload)-offset {
+			return nil, fmt.Errorf("invalid QuickTime metadata key size")
+		}
+		if string(payload[offset+4:offset+8]) != "mdta" {
+			keys = append(keys, "")
+		} else {
+			keys = append(keys, string(payload[offset+8:offset+entrySize]))
+		}
+		offset += entrySize
+	}
+	return keys, nil
+}
+
+func readQuickTimeItemValue(reader io.ReaderAt, itemList mp4Box, wantedIndex uint32) (string, bool, error) {
+	items, err := readDirectMP4Boxes(reader, itemList.payloadStart, itemList.end)
+	if err != nil {
+		return "", false, err
+	}
+	for _, item := range items {
+		if binary.BigEndian.Uint32(item.typ[:]) != wantedIndex {
+			continue
+		}
+		values, err := readDirectMP4Boxes(reader, item.payloadStart, item.end)
+		if err != nil {
+			return "", false, err
+		}
+		for _, value := range values {
+			if string(value.typ[:]) != "data" || value.end-value.payloadStart < 8 {
+				continue
+			}
+			payload, err := readBoxPayload(reader, value, maxContentIdentifier+8)
+			if err != nil {
+				return "", false, err
+			}
+			return string(payload[8:]), true, nil
+		}
+	}
+	return "", false, nil
+}
+
+func readStillImageTimeTrack(reader io.ReaderAt, sampleTable mp4Box) (bool, error) {
+	children, err := readDirectMP4Boxes(reader, sampleTable.payloadStart, sampleTable.end)
+	if err != nil {
+		return false, err
+	}
+	var sampleDescription, sampleSizes, chunkOffsets *mp4Box
+	for index := range children {
+		switch string(children[index].typ[:]) {
+		case "stsd":
+			sampleDescription = &children[index]
+		case "stsz":
+			sampleSizes = &children[index]
+		case "stco", "co64":
+			chunkOffsets = &children[index]
+		}
+	}
+	if sampleDescription == nil || sampleSizes == nil || chunkOffsets == nil {
+		return false, nil
+	}
+
+	isTimedTrack, err := sampleDescriptionContainsStillImageTime(reader, *sampleDescription)
+	if err != nil || !isTimedTrack {
+		return false, err
+	}
+	sampleSize, err := readFirstSampleSize(reader, *sampleSizes)
+	if err != nil {
+		return false, err
+	}
+	sampleOffset, err := readFirstChunkOffset(reader, *chunkOffsets)
+	if err != nil {
+		return false, err
+	}
+	if sampleSize < 9 || sampleSize > 1<<20 {
+		return false, nil
+	}
+	sample := make([]byte, sampleSize)
+	if _, err := reader.ReadAt(sample, sampleOffset); err != nil {
+		return false, fmt.Errorf("read still-image-time sample: %w", err)
+	}
+	return sampleContainsStillImageTime(sample)
+}
+
+func sampleContainsStillImageTime(sample []byte) (bool, error) {
+	// A timed metadata sample may contain several length-prefixed values, so walk
+	// every record instead of assuming the still-image-time value fills the sample.
+	for offset := 0; offset < len(sample); {
+		if len(sample)-offset < 8 {
+			return false, fmt.Errorf("truncated timed metadata value")
+		}
+		valueSize := int(binary.BigEndian.Uint32(sample[offset : offset+4]))
+		if valueSize < 9 || valueSize > len(sample)-offset {
+			return false, fmt.Errorf("invalid timed metadata value size")
+		}
+		keyIndex := binary.BigEndian.Uint32(sample[offset+4 : offset+8])
+		if keyIndex == 1 && sample[offset+8] == 0xff {
+			return true, nil
+		}
+		offset += valueSize
+	}
+	return false, nil
+}
+
+func sampleDescriptionContainsStillImageTime(reader io.ReaderAt, box mp4Box) (bool, error) {
+	payload, err := readBoxPayload(reader, box, 4<<20)
+	if err != nil {
+		return false, err
+	}
+	if len(payload) < 8 {
+		return false, fmt.Errorf("truncated sample description")
+	}
+	entryCount := int(binary.BigEndian.Uint32(payload[4:8]))
+	offset := 8
+	needle := []byte("com.apple.quicktime.still-image-time")
+	for index := 0; index < entryCount; index++ {
+		if len(payload)-offset < 8 {
+			return false, fmt.Errorf("truncated sample description entry")
+		}
+		entrySize := int(binary.BigEndian.Uint32(payload[offset : offset+4]))
+		if entrySize < 8 || entrySize > len(payload)-offset {
+			return false, fmt.Errorf("invalid sample description entry size")
+		}
+		if string(payload[offset+4:offset+8]) == "mebx" && bytes.Contains(payload[offset+8:offset+entrySize], needle) {
+			return true, nil
+		}
+		offset += entrySize
+	}
+	return false, nil
+}
+
+func readFirstSampleSize(reader io.ReaderAt, box mp4Box) (uint32, error) {
+	payload, err := readBoxPayload(reader, box, 1<<20)
+	if err != nil {
+		return 0, err
+	}
+	if len(payload) < 12 {
+		return 0, fmt.Errorf("truncated sample size box")
+	}
+	fixedSize := binary.BigEndian.Uint32(payload[4:8])
+	sampleCount := binary.BigEndian.Uint32(payload[8:12])
+	if sampleCount == 0 {
+		return 0, fmt.Errorf("still-image-time track has no samples")
+	}
+	if fixedSize != 0 {
+		return fixedSize, nil
+	}
+	if len(payload) < 16 {
+		return 0, fmt.Errorf("truncated variable sample size box")
+	}
+	return binary.BigEndian.Uint32(payload[12:16]), nil
+}
+
+func readFirstChunkOffset(reader io.ReaderAt, box mp4Box) (int64, error) {
+	payload, err := readBoxPayload(reader, box, 1<<20)
+	if err != nil {
+		return 0, err
+	}
+	if len(payload) < 12 || binary.BigEndian.Uint32(payload[4:8]) == 0 {
+		return 0, fmt.Errorf("still-image-time track has no chunks")
+	}
+	if string(box.typ[:]) == "co64" {
+		if len(payload) < 16 {
+			return 0, fmt.Errorf("truncated 64-bit chunk offset box")
+		}
+		offset := binary.BigEndian.Uint64(payload[8:16])
+		if offset > uint64(^uint64(0)>>1) {
+			return 0, fmt.Errorf("chunk offset is too large")
+		}
+		return int64(offset), nil
+	}
+	return int64(binary.BigEndian.Uint32(payload[8:12])), nil
+}
+
+func readBoxPayload(reader io.ReaderAt, box mp4Box, maxSize int64) ([]byte, error) {
+	size := box.end - box.payloadStart
+	if size < 0 || size > maxSize {
+		return nil, fmt.Errorf("%s box payload is too large", string(box.typ[:]))
+	}
+	payload := make([]byte, size)
+	if _, err := reader.ReadAt(payload, box.payloadStart); err != nil {
+		return nil, fmt.Errorf("read %s box payload: %w", string(box.typ[:]), err)
+	}
+	return payload, nil
+}

--- a/backend/livephoto_upload.go
+++ b/backend/livephoto_upload.go
@@ -1,0 +1,186 @@
+package backend
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+type livePhotoUploadAPI interface {
+	FindRemoteMediaByHash(hash []byte) (string, error)
+	GetUploadToken(sha1Hash string, fileSize int64) (string, error)
+	UploadFileWithProgress(ctx context.Context, filePath string, uploadToken string, onProgress UploadProgressCallback) (ScottyFinalizeToken, error)
+	CommitLivePhoto(input LivePhotoCreateRequest) (string, error)
+}
+
+type LivePhotoUploadOptions struct {
+	Policy              LivePhotoCommitPolicy
+	DeleteFromHost      bool
+	SetDateFromFilename bool
+}
+
+func uploadLivePhotoWithCallback(
+	ctx context.Context,
+	api livePhotoUploadAPI,
+	pair LivePhotoPair,
+	options LivePhotoUploadOptions,
+	workerID int,
+	callback ProgressCallback,
+) (mediaKey string, skipped bool, err error) {
+	photoInfo, err := os.Stat(pair.PhotoPath)
+	if err != nil {
+		return "", false, fmt.Errorf("stat Live Photo still: %w", err)
+	}
+	videoInfo, err := os.Stat(pair.VideoPath)
+	if err != nil {
+		return "", false, fmt.Errorf("stat Live Photo video: %w", err)
+	}
+	totalBytes := photoInfo.Size() + videoInfo.Size()
+	displayName := filepath.Base(pair.PhotoPath) + " + " + filepath.Base(pair.VideoPath)
+	emitLivePhotoStatus(callback, ThreadStatus{
+		WorkerID: workerID,
+		Status:   "hashing",
+		FilePath: pair.PhotoPath,
+		FileName: displayName,
+		Message:  "Hashing Live Photo pair...",
+	})
+
+	photoSHA1, err := CalculateSHA1(ctx, pair.PhotoPath)
+	if err != nil {
+		return "", false, fmt.Errorf("hash Live Photo still: %w", err)
+	}
+	videoSHA1, err := CalculateSHA1(ctx, pair.VideoPath)
+	if err != nil {
+		return "", false, fmt.Errorf("hash Live Photo video: %w", err)
+	}
+
+	// Pairs are new-item-only: the private reconciliation branch for partially
+	// remote pairs is known statically but has not been recovered on the wire.
+	// Skip the entire pair when either hash exists rather than risk a duplicate or
+	// unlinked component; Force Upload therefore remains a single-file feature.
+	emitLivePhotoStatus(callback, ThreadStatus{
+		WorkerID: workerID,
+		Status:   "checking",
+		FilePath: pair.PhotoPath,
+		FileName: displayName,
+		Message:  "Checking both Live Photo components...",
+	})
+	photoRemoteKey, photoCheckErr := api.FindRemoteMediaByHash(photoSHA1)
+	videoRemoteKey, videoCheckErr := api.FindRemoteMediaByHash(videoSHA1)
+	if photoCheckErr != nil {
+		return "", false, fmt.Errorf("check Live Photo still deduplication: %w", photoCheckErr)
+	}
+	if videoCheckErr != nil {
+		return "", false, fmt.Errorf("check Live Photo video deduplication: %w", videoCheckErr)
+	}
+	if photoRemoteKey != "" || videoRemoteKey != "" {
+		emitLivePhotoStatus(callback, ThreadStatus{
+			WorkerID: workerID,
+			Status:   "skipped",
+			FilePath: pair.PhotoPath,
+			FileName: displayName,
+			Message:  "Skipped: a Live Photo component already exists remotely",
+		})
+		return "", true, nil
+	}
+
+	photoToken, err := uploadLivePhotoComponent(ctx, api, pair.PhotoPath, photoInfo.Size(), photoSHA1, 0, totalBytes, workerID, displayName, callback)
+	if err != nil {
+		return "", false, fmt.Errorf("upload Live Photo still: %w", err)
+	}
+	videoToken, err := uploadLivePhotoComponent(ctx, api, pair.VideoPath, videoInfo.Size(), videoSHA1, photoInfo.Size(), totalBytes, workerID, displayName, callback)
+	if err != nil {
+		return "", false, fmt.Errorf("upload Live Photo video: %w", err)
+	}
+
+	uploadTime := photoInfo.ModTime()
+	if options.SetDateFromFilename {
+		if parsed, ok := parseTimestampFromFilename(pair.PhotoPath); ok {
+			uploadTime = parsed
+		}
+	}
+	emitLivePhotoStatus(callback, ThreadStatus{
+		WorkerID: workerID,
+		Status:   "finalizing",
+		FilePath: pair.PhotoPath,
+		FileName: displayName,
+		Message:  "Committing linked Live Photo...",
+	})
+	mediaKey, err = api.CommitLivePhoto(LivePhotoCreateRequest{
+		PhotoToken:       photoToken,
+		VideoToken:       videoToken,
+		FileName:         photoInfo.Name(),
+		PhotoSHA1:        photoSHA1,
+		VideoSHA1:        videoSHA1,
+		CreatedAt:        uploadTime,
+		ModifiedAt:       uploadTime,
+		StoragePolicy:    options.Policy.StoragePolicy,
+		UploadQuality:    options.Policy.UploadQuality,
+		UploadDeviceInfo: options.Policy.UploadDeviceInfo,
+	})
+	if err != nil {
+		return "", false, fmt.Errorf("commit Live Photo: %w", err)
+	}
+	if mediaKey == "" {
+		return "", false, fmt.Errorf("Live Photo media key not received")
+	}
+
+	if options.DeleteFromHost {
+		if err := removeLivePhotoFiles(pair); err != nil {
+			return mediaKey, false, err
+		}
+	}
+	return mediaKey, false, nil
+}
+
+func uploadLivePhotoComponent(
+	ctx context.Context,
+	api livePhotoUploadAPI,
+	path string,
+	size int64,
+	hash []byte,
+	completedBytes int64,
+	totalBytes int64,
+	workerID int,
+	displayName string,
+	callback ProgressCallback,
+) (ScottyFinalizeToken, error) {
+	uploadSession, err := api.GetUploadToken(base64.StdEncoding.EncodeToString(hash), size)
+	if err != nil {
+		return ScottyFinalizeToken{}, err
+	}
+	progress := func(bytesUploaded, _ int64, attempt int) {
+		message := "Uploading Live Photo pair..."
+		if attempt > 1 {
+			message = fmt.Sprintf("Retrying Live Photo component (attempt %d)...", attempt)
+		}
+		emitLivePhotoStatus(callback, ThreadStatus{
+			WorkerID:      workerID,
+			Status:        "uploading",
+			FilePath:      path,
+			FileName:      displayName,
+			Message:       message,
+			BytesUploaded: completedBytes + bytesUploaded,
+			BytesTotal:    totalBytes,
+			Attempt:       attempt,
+		})
+	}
+	return api.UploadFileWithProgress(ctx, path, uploadSession, progress)
+}
+
+func emitLivePhotoStatus(callback ProgressCallback, status ThreadStatus) {
+	if callback != nil {
+		callback("ThreadStatus", status)
+	}
+}
+
+func removeLivePhotoFiles(pair LivePhotoPair) error {
+	for _, path := range []string{pair.VideoPath, pair.PhotoPath} {
+		if err := os.Remove(path); err != nil {
+			return fmt.Errorf("Live Photo uploaded but failed to delete %s: %w", filepath.Base(path), err)
+		}
+	}
+	return nil
+}

--- a/backend/scotty_token.go
+++ b/backend/scotty_token.go
@@ -1,0 +1,82 @@
+package backend
+
+import (
+	"bytes"
+	"fmt"
+
+	"app/generated"
+
+	"google.golang.org/protobuf/encoding/protowire"
+	"google.golang.org/protobuf/proto"
+)
+
+const scottyFinalizeTokenVersion = 2
+
+// ScottyFinalizeToken retains the complete upload-finalize response because
+// create-media embeds the outer envelope byte-for-byte, not just field 2. All
+// observed envelopes used field 1 == 2 and one protected, opaque field 2; its
+// contents and the two observed envelope lengths must not be interpreted as a
+// media type or normalized by decoding and re-encoding.
+type ScottyFinalizeToken struct {
+	Raw []byte
+}
+
+func ParseScottyFinalizeToken(raw []byte) (ScottyFinalizeToken, error) {
+	field1Count := 0
+	field2Count := 0
+	for offset := 0; offset < len(raw); {
+		number, wireType, tagLength := protowire.ConsumeTag(raw[offset:])
+		if tagLength < 0 {
+			return ScottyFinalizeToken{}, fmt.Errorf("invalid Scotty finalize token tag: %w", protowire.ParseError(tagLength))
+		}
+		value := raw[offset+tagLength:]
+		valueLength := protowire.ConsumeFieldValue(number, wireType, value)
+		if valueLength < 0 {
+			return ScottyFinalizeToken{}, fmt.Errorf("invalid Scotty finalize token field %d: %w", number, protowire.ParseError(valueLength))
+		}
+
+		switch number {
+		case 1:
+			if wireType != protowire.VarintType {
+				return ScottyFinalizeToken{}, fmt.Errorf("Scotty finalize token field 1 has wire type %d", wireType)
+			}
+			version, consumed := protowire.ConsumeVarint(value)
+			if consumed != valueLength || version != scottyFinalizeTokenVersion {
+				return ScottyFinalizeToken{}, fmt.Errorf("unsupported Scotty finalize token version %d", version)
+			}
+			field1Count++
+		case 2:
+			if wireType != protowire.BytesType {
+				return ScottyFinalizeToken{}, fmt.Errorf("Scotty finalize token field 2 has wire type %d", wireType)
+			}
+			opaque, consumed := protowire.ConsumeBytes(value)
+			if consumed != valueLength || len(opaque) == 0 {
+				return ScottyFinalizeToken{}, fmt.Errorf("Scotty finalize token field 2 is empty or incomplete")
+			}
+			field2Count++
+		}
+		offset += tagLength + valueLength
+	}
+
+	if field1Count != 1 {
+		return ScottyFinalizeToken{}, fmt.Errorf("Scotty finalize token contains %d field-1 values, want 1", field1Count)
+	}
+	if field2Count != 1 {
+		return ScottyFinalizeToken{}, fmt.Errorf("Scotty finalize token contains %d field-2 values, want 1", field2Count)
+	}
+	return ScottyFinalizeToken{Raw: bytes.Clone(raw)}, nil
+}
+
+// legacyCommitToken keeps the established single-file CommitUpload path intact.
+// Linked Live Photos bypass this conversion and embed token.Raw unchanged.
+func (token ScottyFinalizeToken) legacyCommitToken() (*generated.CommitToken, error) {
+	validated, err := ParseScottyFinalizeToken(token.Raw)
+	if err != nil {
+		return nil, err
+	}
+	var decoded generated.CommitToken
+	if err := proto.Unmarshal(validated.Raw, &decoded); err != nil {
+		return nil, fmt.Errorf("decode legacy commit token: %w", err)
+	}
+	return &decoded, nil
+}

--- a/backend/upload.go
+++ b/backend/upload.go
@@ -540,9 +540,13 @@ func uploadFileWithCallback(ctx context.Context, api *Api, filePath string, work
 		})
 	}
 
-	CommitToken, err := api.UploadFileWithProgress(ctx, filePath, token, progressCallback)
+	finalizeToken, err := api.UploadFileWithProgress(ctx, filePath, token, progressCallback)
 	if err != nil {
 		return "", fmt.Errorf("error uploading file: %w", err)
+	}
+	commitToken, err := finalizeToken.legacyCommitToken()
+	if err != nil {
+		return "", fmt.Errorf("error decoding upload finalize token: %w", err)
 	}
 
 	// Stage 4: Finalizing
@@ -554,7 +558,7 @@ func uploadFileWithCallback(ctx context.Context, api *Api, filePath string, work
 		Message:  "Committing upload...",
 	})
 
-	mediaKey, err := api.CommitUpload(CommitToken, fileInfo.Name(), sha1_hash_bytes, uploadTimestamp)
+	mediaKey, err := api.CommitUpload(commitToken, fileInfo.Name(), sha1_hash_bytes, uploadTimestamp)
 	if err != nil {
 		return "", fmt.Errorf("error committing file: %w", err)
 	}

--- a/backend/upload.go
+++ b/backend/upload.go
@@ -84,16 +84,21 @@ type UploadBatchStart struct {
 }
 
 type FileUploadResult struct {
-	MediaKey     string `json:"MediaKey"`
-	IsError      bool   `json:"IsError"`
-	Error        error  `json:"-"`
-	ErrorMessage string `json:"ErrorMessage"`
-	Path         string `json:"Path"`
+	MediaKey     string   `json:"MediaKey"`
+	IsError      bool     `json:"IsError"`
+	IsLivePhoto  bool     `json:"IsLivePhoto"`
+	Skipped      bool     `json:"Skipped"`
+	SkipCode     string   `json:"SkipCode"`
+	SkipReason   string   `json:"SkipReason"`
+	Error        error    `json:"-"`
+	ErrorMessage string   `json:"ErrorMessage"`
+	Path         string   `json:"Path"`
+	Paths        []string `json:"Paths"`
 }
 
 type ThreadStatus struct {
 	WorkerID      int    `json:"WorkerID"`
-	Status        string `json:"Status"` // "idle", "hashing", "checking", "uploading", "finalizing", "completed", "error"
+	Status        string `json:"Status"` // "idle", "hashing", "checking", "uploading", "finalizing", "completed", "skipped", "error"
 	FilePath      string `json:"FilePath"`
 	FileName      string `json:"FileName"`
 	Message       string `json:"Message"`
@@ -126,8 +131,13 @@ func (m *UploadManager) Upload(app AppInterface, paths []string) {
 		m.mu.Unlock()
 		return
 	}
+	workItems, preflightWarnings := ClassifyUploadWork(targetPaths, LivePhotoClassificationOptions{
+		Enabled:        AppConfig.PairLivePhotos,
+		SkipIncomplete: AppConfig.SkipIncompleteLivePhotos,
+	}, nil)
+	emitUploadPreflight(app, len(workItems), preflightWarnings)
 
-	if len(targetPaths) == 0 {
+	if len(workItems) == 0 {
 		app.EmitEvent("uploadStop", nil)
 		m.mu.Lock()
 		m.running = false
@@ -137,12 +147,13 @@ func (m *UploadManager) Upload(app AppInterface, paths []string) {
 
 	// Emit uploadStart immediately with TotalBytes=0 for responsive UI
 	app.EmitEvent("uploadStart", UploadBatchStart{
-		Total:      len(targetPaths),
+		Total:      len(workItems),
 		TotalBytes: 0,
 	})
 
 	if _, err := NewApi(); err != nil {
-		for _, path := range targetPaths {
+		for _, item := range workItems {
+			path := uploadWorkPrimaryPath(item)
 			app.EmitEvent("FileStatus", FileUploadResult{
 				IsError:      true,
 				Error:        err,
@@ -160,9 +171,11 @@ func (m *UploadManager) Upload(app AppInterface, paths []string) {
 	// Calculate total bytes asynchronously and emit update when complete
 	go func() {
 		var totalBytes int64
-		for _, path := range targetPaths {
-			if info, err := os.Stat(path); err == nil {
-				totalBytes += info.Size()
+		for _, item := range workItems {
+			for _, path := range uploadWorkPaths(item) {
+				if info, err := os.Stat(path); err == nil {
+					totalBytes += info.Size()
+				}
 			}
 		}
 		app.EmitEvent("uploadTotalBytes", totalBytes)
@@ -173,11 +186,11 @@ func (m *UploadManager) Upload(app AppInterface, paths []string) {
 	}
 
 	// Don't start more threads than files to process
-	numWorkers := min(AppConfig.UploadThreads, len(targetPaths))
+	numWorkers := min(AppConfig.UploadThreads, len(workItems))
 
 	// Create a worker pool for concurrent uploads
-	workChan := make(chan string, len(targetPaths))
-	results := make(chan FileUploadResult, len(targetPaths))
+	workChan := make(chan UploadWorkItem, len(workItems))
+	results := make(chan FileUploadResult, len(workItems))
 
 	// Start workers
 	for i := range numWorkers {
@@ -188,11 +201,11 @@ func (m *UploadManager) Upload(app AppInterface, paths []string) {
 	// Send work to workers
 	go func() {
 	LOOP:
-		for _, path := range targetPaths {
+		for _, item := range workItems {
 			select {
 			case <-m.cancel:
 				break LOOP
-			case workChan <- path:
+			case workChan <- item:
 			}
 		}
 		close(workChan)
@@ -239,6 +252,40 @@ func (m *UploadManager) Upload(app AppInterface, paths []string) {
 		m.running = false
 		m.mu.Unlock()
 	}()
+}
+
+func emitUploadPreflight(app AppInterface, uploadItemCount int, warnings []PreflightWarning) {
+	skippedCount := 0
+	for _, warning := range warnings {
+		if warning.Code == "incomplete-live-photo-skipped" {
+			skippedCount++
+		}
+	}
+
+	// Start before emitting warnings/results so the frontend resets its previous
+	// batch while retaining every event from this preflight.
+	app.EmitEvent("uploadStart", UploadBatchStart{
+		Total:      uploadItemCount + skippedCount,
+		TotalBytes: 0,
+	})
+	for _, warning := range warnings {
+		app.EmitEvent("livePhotoPreflightWarning", warning)
+		if warning.Code != "incomplete-live-photo-skipped" {
+			continue
+		}
+		primaryPath := ""
+		if len(warning.Paths) > 0 {
+			primaryPath = warning.Paths[0]
+		}
+		app.EmitEvent("FileStatus", FileUploadResult{
+			IsLivePhoto: true,
+			Skipped:     true,
+			SkipCode:    warning.Code,
+			SkipReason:  warning.Message,
+			Path:        primaryPath,
+			Paths:       warning.Paths,
+		})
+	}
 }
 
 // handleAlbumCreation handles album creation based on config (manual name/key or AUTO mode)
@@ -576,7 +623,7 @@ func uploadFileWithCallback(ctx context.Context, api *Api, filePath string, work
 	return mediaKey, nil
 }
 
-func startUploadWorker(workerID int, workChan <-chan string, results chan<- FileUploadResult, cancel <-chan struct{}, wg *sync.WaitGroup, app AppInterface) {
+func startUploadWorker(workerID int, workChan <-chan UploadWorkItem, results chan<- FileUploadResult, cancel <-chan struct{}, wg *sync.WaitGroup, app AppInterface) {
 	defer wg.Done()
 
 	// Emit idle status initially
@@ -602,7 +649,7 @@ func startUploadWorker(workerID int, workChan <-chan string, results chan<- File
 		app.EmitEvent(event, data)
 	}
 
-	for path := range workChan {
+	for item := range workChan {
 		select {
 		case <-cancel:
 			app.EmitEvent("ThreadStatus", ThreadStatus{
@@ -622,9 +669,12 @@ func startUploadWorker(workerID int, workChan <-chan string, results chan<- File
 				}
 			}()
 
-			mediaKey, err := uploadFileWithCallback(ctx, api, path, workerID, callback)
+			path := uploadWorkPrimaryPath(item)
+			paths := uploadWorkPaths(item)
+			isLivePhoto := item.Kind == UploadWorkLivePhoto
+			mediaKey, skipped, err := uploadWorkItem(ctx, api, item, workerID, callback)
 			if err != nil {
-				results <- FileUploadResult{IsError: true, Error: err, ErrorMessage: err.Error(), Path: path}
+				results <- FileUploadResult{IsError: true, IsLivePhoto: isLivePhoto, Error: err, ErrorMessage: err.Error(), Path: path, Paths: paths}
 				app.EmitEvent("ThreadStatus", ThreadStatus{
 					WorkerID: workerID,
 					Status:   "error",
@@ -632,8 +682,23 @@ func startUploadWorker(workerID int, workChan <-chan string, results chan<- File
 					FileName: filepath.Base(path),
 					Message:  fmt.Sprintf("Error: %v", err),
 				})
+			} else if skipped {
+				skipCode := "remote-duplicate"
+				skipReason := "Skipped because this file already exists remotely"
+				if isLivePhoto {
+					skipCode = "remote-live-photo-component-exists"
+					skipReason = "Skipped because a Live Photo component already exists remotely"
+				}
+				results <- FileUploadResult{
+					IsLivePhoto: isLivePhoto,
+					Skipped:     true,
+					SkipCode:    skipCode,
+					SkipReason:  skipReason,
+					Path:        path,
+					Paths:       paths,
+				}
 			} else {
-				results <- FileUploadResult{IsError: false, Path: path, MediaKey: mediaKey}
+				results <- FileUploadResult{IsLivePhoto: isLivePhoto, Path: path, Paths: paths, MediaKey: mediaKey}
 				app.EmitEvent("ThreadStatus", ThreadStatus{
 					WorkerID: workerID,
 					Status:   "completed",
@@ -659,4 +724,44 @@ func startUploadWorker(workerID int, workChan <-chan string, results chan<- File
 		Status:   "idle",
 		Message:  "Finished",
 	})
+}
+
+func uploadWorkItem(ctx context.Context, api *Api, item UploadWorkItem, workerID int, callback ProgressCallback) (string, bool, error) {
+	switch item.Kind {
+	case UploadWorkSingle:
+		if item.Single == nil || item.LivePhoto != nil {
+			return "", false, fmt.Errorf("invalid single-media work item")
+		}
+		mediaKey, err := uploadFileWithCallback(ctx, api, item.Single.Path, workerID, callback)
+		return mediaKey, false, err
+	case UploadWorkLivePhoto:
+		if item.LivePhoto == nil || item.Single != nil {
+			return "", false, fmt.Errorf("invalid Live Photo work item")
+		}
+		return uploadLivePhotoWithCallback(ctx, api, *item.LivePhoto, LivePhotoUploadOptions{
+			Policy:              buildLivePhotoCommitPolicy(api, AppConfig),
+			DeleteFromHost:      AppConfig.DeleteFromHost,
+			SetDateFromFilename: AppConfig.SetDateFromFilename,
+		}, workerID, callback)
+	default:
+		return "", false, fmt.Errorf("unsupported upload work kind %q", item.Kind)
+	}
+}
+
+func uploadWorkPaths(item UploadWorkItem) []string {
+	if item.Kind == UploadWorkLivePhoto && item.LivePhoto != nil {
+		return []string{item.LivePhoto.PhotoPath, item.LivePhoto.VideoPath}
+	}
+	if item.Single != nil {
+		return []string{item.Single.Path}
+	}
+	return nil
+}
+
+func uploadWorkPrimaryPath(item UploadWorkItem) string {
+	paths := uploadWorkPaths(item)
+	if len(paths) == 0 {
+		return ""
+	}
+	return paths[0]
 }

--- a/backend/upload.go
+++ b/backend/upload.go
@@ -145,12 +145,6 @@ func (m *UploadManager) Upload(app AppInterface, paths []string) {
 		return
 	}
 
-	// Emit uploadStart immediately with TotalBytes=0 for responsive UI
-	app.EmitEvent("uploadStart", UploadBatchStart{
-		Total:      len(workItems),
-		TotalBytes: 0,
-	})
-
 	if _, err := NewApi(); err != nil {
 		for _, item := range workItems {
 			path := uploadWorkPrimaryPath(item)

--- a/backend/wails_events.go
+++ b/backend/wails_events.go
@@ -12,6 +12,7 @@ func init() {
 	application.RegisterEvent[application.Void]("uploadStop")
 	application.RegisterEvent[FileUploadResult]("FileStatus")
 	application.RegisterEvent[ThreadStatus]("ThreadStatus")
+	application.RegisterEvent[PreflightWarning]("livePhotoPreflightWarning")
 	application.RegisterEvent[application.Void]("uploadCancel")
 	application.RegisterEvent[int64]("uploadTotalBytes")
 	application.RegisterEvent[FilesDroppedEvent]("files-dropped")

--- a/cli.go
+++ b/cli.go
@@ -21,6 +21,10 @@ type cliConfig struct {
 	deleteFromHost                bool
 	disableUnsupportedFilesFilter bool
 	setDateFromFilename           bool
+	pairLivePhotos                bool
+	pairLivePhotosSet             bool
+	skipIncompleteLivePhotos      bool
+	skipIncompleteLivePhotosSet   bool
 	excludePattern                string
 	logLevel                      string
 	configPath                    string
@@ -40,10 +44,14 @@ type fileProgressMsg struct {
 }
 
 type fileCompleteMsg struct {
-	success  bool
-	fileName string
-	mediaKey string
-	err      error
+	success    bool
+	skipped    bool
+	fileName   string
+	paths      []string
+	mediaKey   string
+	skipCode   string
+	skipReason string
+	err        error
 }
 
 type uploadCompleteMsg struct{}
@@ -72,6 +80,7 @@ type uploadModel struct {
 	totalFiles   int
 	completed    int
 	failed       int
+	skipped      int
 	currentFiles map[int]string // workerID -> current file
 	workers      map[int]string // workerID -> status message
 	results      []uploadResult // Track all upload results
@@ -87,10 +96,14 @@ type uploadModel struct {
 }
 
 type uploadResult struct {
-	Path     string `json:"path"`
-	Success  bool   `json:"success"`
-	MediaKey string `json:"mediaKey,omitempty"`
-	Error    string `json:"error,omitempty"`
+	Path       string   `json:"path"`
+	Paths      []string `json:"paths,omitempty"`
+	Success    bool     `json:"success"`
+	Skipped    bool     `json:"skipped,omitempty"`
+	MediaKey   string   `json:"mediaKey,omitempty"`
+	SkipCode   string   `json:"skipCode,omitempty"`
+	SkipReason string   `json:"skipReason,omitempty"`
+	Error      string   `json:"error,omitempty"`
 }
 
 type albumSummary struct {
@@ -104,6 +117,7 @@ type uploadSummary struct {
 	Total     int            `json:"total"`
 	Succeeded int            `json:"succeeded"`
 	Failed    int            `json:"failed"`
+	Skipped   int            `json:"skipped"`
 	Results   []uploadResult `json:"results"`
 	Album     *albumSummary  `json:"album,omitempty"`
 }
@@ -142,11 +156,17 @@ func (m uploadModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case fileCompleteMsg:
 		result := uploadResult{
-			Path:     msg.fileName,
-			Success:  msg.success,
-			MediaKey: msg.mediaKey,
+			Path:       msg.fileName,
+			Paths:      msg.paths,
+			Success:    msg.success,
+			Skipped:    msg.skipped,
+			MediaKey:   msg.mediaKey,
+			SkipCode:   msg.skipCode,
+			SkipReason: msg.skipReason,
 		}
-		if msg.success {
+		if msg.skipped {
+			m.skipped++
+		} else if msg.success {
 			m.completed++
 		} else {
 			m.failed++
@@ -203,10 +223,10 @@ func (m uploadModel) View() string {
 
 	// Progress bar
 	if m.totalFiles > 0 {
-		percent := float64(m.completed+m.failed) / float64(m.totalFiles)
+		percent := float64(m.completed+m.failed+m.skipped) / float64(m.totalFiles)
 		b.WriteString(m.progress.ViewAs(percent))
-		fmt.Fprintf(&b, "\n%d/%d files", m.completed+m.failed, m.totalFiles)
-		fmt.Fprintf(&b, " (✓ %d success, ✗ %d failed)\n\n", m.completed, m.failed)
+		fmt.Fprintf(&b, "\n%d/%d items", m.completed+m.failed+m.skipped, m.totalFiles)
+		fmt.Fprintf(&b, " (✓ %d success, ↷ %d skipped, ✗ %d failed)\n\n", m.completed, m.skipped, m.failed)
 	}
 
 	// Worker status
@@ -280,6 +300,12 @@ func runCLIUpload(filePaths []string, config cliConfig) error {
 	backend.AppConfig.DisableUnsupportedFilesFilter = config.disableUnsupportedFilesFilter
 	backend.AppConfig.SetDateFromFilename = config.setDateFromFilename
 	backend.AppConfig.ExcludePattern = config.excludePattern
+	if config.pairLivePhotosSet {
+		backend.AppConfig.PairLivePhotos = config.pairLivePhotos
+	}
+	if config.skipIncompleteLivePhotosSet {
+		backend.AppConfig.SkipIncompleteLivePhotos = config.skipIncompleteLivePhotos
+	}
 
 	// Handle album option - check for AUTO mode
 	if strings.ToUpper(config.albumName) == "AUTO" {
@@ -318,10 +344,14 @@ func runCLIUpload(filePaths []string, config cliConfig) error {
 		case "FileStatus":
 			if result, ok := data.(backend.FileUploadResult); ok {
 				p.Send(fileCompleteMsg{
-					success:  !result.IsError,
-					fileName: result.Path,
-					mediaKey: result.MediaKey,
-					err:      result.Error,
+					success:    !result.IsError && !result.Skipped,
+					skipped:    result.Skipped,
+					fileName:   result.Path,
+					paths:      result.Paths,
+					mediaKey:   result.MediaKey,
+					skipCode:   result.SkipCode,
+					skipReason: result.SkipReason,
+					err:        result.Error,
 				})
 			}
 		case "uploadStop":
@@ -368,22 +398,7 @@ func runCLIUpload(filePaths []string, config cliConfig) error {
 
 	// Print JSON summary after TUI completes
 	if m, ok := finalModel.(uploadModel); ok {
-		summary := uploadSummary{
-			Total:     m.totalFiles,
-			Succeeded: m.completed,
-			Failed:    m.failed,
-			Results:   m.results,
-		}
-
-		// Add album info if present
-		if m.albumName != "" {
-			summary.Album = &albumSummary{
-				Name:       m.albumName,
-				ItemsAdded: m.albumItemsAdded,
-				AlbumKeys:  m.albumKeys,
-				Error:      m.albumError,
-			}
-		}
+		summary := buildUploadSummary(m)
 
 		jsonOutput, err := json.MarshalIndent(summary, "", "  ")
 		if err != nil {
@@ -394,4 +409,23 @@ func runCLIUpload(filePaths []string, config cliConfig) error {
 	}
 
 	return nil
+}
+
+func buildUploadSummary(model uploadModel) uploadSummary {
+	summary := uploadSummary{
+		Total:     model.totalFiles,
+		Succeeded: model.completed,
+		Failed:    model.failed,
+		Skipped:   model.skipped,
+		Results:   model.results,
+	}
+	if model.albumName != "" {
+		summary.Album = &albumSummary{
+			Name:       model.albumName,
+			ItemsAdded: model.albumItemsAdded,
+			AlbumKeys:  model.albumKeys,
+			Error:      model.albumError,
+		}
+	}
+	return summary
 }

--- a/cli_shared.go
+++ b/cli_shared.go
@@ -42,11 +42,14 @@ func runCLI() {
 	case "upload":
 		// Check for help flag first
 		if len(os.Args) > 2 && (os.Args[2] == "--help" || os.Args[2] == "-h") {
-			fmt.Printf("Usage: %s upload <filepath> [flags]\n", cliExecutableName)
+			fmt.Printf("Usage: %s upload <path> [<path> ...] [flags]\n", cliExecutableName)
 			fmt.Println("\nFlags:")
 			fmt.Println("  -r, --recursive              Include subdirectories")
 			fmt.Println("  -t, --threads <n>            Number of upload threads (default: 3)")
 			fmt.Println("  -f, --force                  Force upload even if file exists")
+			fmt.Println("  --pair-live-photos           Pair Apple Live Photo files; incomplete pairs are skipped")
+			fmt.Println("  --skip-incomplete-live-photos  Skip incomplete Live Photo members")
+			fmt.Println("  --upload-incomplete-live-photos  Upload an unmatched member as a single file")
 			fmt.Println("  -d, --delete                 Delete from host after upload")
 			fmt.Println("  -df, --disable-filter        Disable file type filtering")
 			fmt.Println("  --date-from-filename         Set media date from filename (e.g. 20240709_182027.jpg)")
@@ -59,70 +62,20 @@ func runCLI() {
 		}
 
 		if len(os.Args) < 3 {
-			fmt.Println("Error: filepath required")
-			fmt.Printf("Usage: %s upload <filepath> [flags]\n", cliExecutableName)
+			fmt.Println("Error: at least one path is required")
+			fmt.Printf("Usage: %s upload <path> [<path> ...] [flags]\n", cliExecutableName)
 			fmt.Printf("\nRun '%s upload --help' for more information\n", cliExecutableName)
 			os.Exit(1)
 		}
 
-		// Parse arguments
-		filePath := os.Args[2]
-
-		// Validate that filepath exists
-		if _, err := os.Stat(filePath); os.IsNotExist(err) {
-			fmt.Fprintf(os.Stderr, "Error: file or directory does not exist: %s\n", filePath)
+		filePaths, config, err := parseUploadArgs(os.Args[2:])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}
 
-		filePaths := []string{filePath}
-		config := cliConfig{
-			threads:  3,
-			logLevel: "info", // Default to info for CLI
-		}
-
-		// Parse flags
-		for i := 3; i < len(os.Args); i++ {
-			switch os.Args[i] {
-			case "--recursive", "-r":
-				config.recursive = true
-			case "--force", "-f":
-				config.forceUpload = true
-			case "--delete", "-d":
-				config.deleteFromHost = true
-			case "--disable-filter", "-df":
-				config.disableUnsupportedFilesFilter = true
-			case "--date-from-filename":
-				config.setDateFromFilename = true
-			case "--exclude", "-e":
-				if i+1 < len(os.Args) {
-					config.excludePattern = os.Args[i+1]
-					i++
-				}
-			case "--threads", "-t":
-				if i+1 < len(os.Args) {
-					_, _ = fmt.Sscanf(os.Args[i+1], "%d", &config.threads)
-					i++
-				}
-			case "--log-level", "-l":
-				if i+1 < len(os.Args) {
-					config.logLevel = os.Args[i+1]
-					i++
-				}
-			case "--config", "-c":
-				if i+1 < len(os.Args) {
-					config.configPath = os.Args[i+1]
-					i++
-				}
-			case "--album", "-a":
-				if i+1 < len(os.Args) {
-					config.albumName = os.Args[i+1]
-					i++
-				}
-			}
-		}
-
 		// Run upload
-		err := runCLIUpload(filePaths, config)
+		err = runCLIUpload(filePaths, config)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Upload failed: %v\n", err)
 			os.Exit(1)
@@ -180,7 +133,7 @@ func printCLIHelp() {
 	fmt.Printf("  %s <command>    Run CLI command\n", cliExecutableName)
 	fmt.Println()
 	fmt.Println("Commands:")
-	fmt.Println("  upload <filepath>   Upload a file to Google Photos")
+	fmt.Println("  upload <path> [<path> ...]   Upload files or directories")
 	fmt.Println("  creds               Manage Google Photos credentials")
 	fmt.Println("  help                Show this help message")
 	fmt.Println("  version             Show version information")

--- a/cli_upload_args.go
+++ b/cli_upload_args.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+func parseUploadArgs(args []string) ([]string, cliConfig, error) {
+	config := cliConfig{
+		threads:  3,
+		logLevel: "info",
+	}
+	paths := make([]string, 0, len(args))
+
+	for index := 0; index < len(args); index++ {
+		argument := args[index]
+		nextValue := func() (string, error) {
+			if index+1 >= len(args) {
+				return "", fmt.Errorf("flag %s requires a value", argument)
+			}
+			index++
+			return args[index], nil
+		}
+
+		switch argument {
+		case "--recursive", "-r":
+			config.recursive = true
+		case "--force", "-f":
+			config.forceUpload = true
+		case "--delete", "-d":
+			config.deleteFromHost = true
+		case "--disable-filter", "-df":
+			config.disableUnsupportedFilesFilter = true
+		case "--date-from-filename":
+			config.setDateFromFilename = true
+		case "--pair-live-photos":
+			config.pairLivePhotos = true
+			config.pairLivePhotosSet = true
+			if !config.skipIncompleteLivePhotosSet {
+				config.skipIncompleteLivePhotos = true
+				config.skipIncompleteLivePhotosSet = true
+			}
+		case "--skip-incomplete-live-photos":
+			config.skipIncompleteLivePhotos = true
+			config.skipIncompleteLivePhotosSet = true
+		case "--upload-incomplete-live-photos":
+			config.skipIncompleteLivePhotos = false
+			config.skipIncompleteLivePhotosSet = true
+		case "--exclude", "-e":
+			value, err := nextValue()
+			if err != nil {
+				return nil, cliConfig{}, err
+			}
+			config.excludePattern = value
+		case "--threads", "-t":
+			value, err := nextValue()
+			if err != nil {
+				return nil, cliConfig{}, err
+			}
+			if _, err := fmt.Sscanf(value, "%d", &config.threads); err != nil || config.threads < 1 {
+				return nil, cliConfig{}, fmt.Errorf("threads must be a positive integer, got %q", value)
+			}
+		case "--log-level", "-l":
+			value, err := nextValue()
+			if err != nil {
+				return nil, cliConfig{}, err
+			}
+			config.logLevel = strings.ToLower(value)
+		case "--config", "-c":
+			value, err := nextValue()
+			if err != nil {
+				return nil, cliConfig{}, err
+			}
+			config.configPath = value
+		case "--album", "-a":
+			value, err := nextValue()
+			if err != nil {
+				return nil, cliConfig{}, err
+			}
+			config.albumName = value
+		default:
+			if strings.HasPrefix(argument, "-") {
+				return nil, cliConfig{}, fmt.Errorf("unknown upload flag %q", argument)
+			}
+			paths = append(paths, argument)
+		}
+	}
+
+	if len(paths) == 0 {
+		return nil, cliConfig{}, fmt.Errorf("at least one file or directory path is required")
+	}
+	for _, path := range paths {
+		if _, err := os.Stat(path); err != nil {
+			return nil, cliConfig{}, fmt.Errorf("invalid upload path %q: %w", path, err)
+		}
+	}
+	return paths, config, nil
+}

--- a/frontend/bindings/app/backend/configmanager.ts
+++ b/frontend/bindings/app/backend/configmanager.ts
@@ -67,6 +67,10 @@ export function SetForceUpload(forceUpload: boolean): $CancellablePromise<void> 
     return $Call.ByID(2189240988, forceUpload);
 }
 
+export function SetPairLivePhotos(pairLivePhotos: boolean): $CancellablePromise<void> {
+    return $Call.ByID(3927958009, pairLivePhotos);
+}
+
 export function SetProxy(proxy: string): $CancellablePromise<void> {
     return $Call.ByID(2532528442, proxy);
 }
@@ -85,6 +89,10 @@ export function SetSelected(email: string): $CancellablePromise<void> {
 
 export function SetSetDateFromFilename(v: boolean): $CancellablePromise<void> {
     return $Call.ByID(1731635347, v);
+}
+
+export function SetSkipIncompleteLivePhotos(skipIncompleteLivePhotos: boolean): $CancellablePromise<void> {
+    return $Call.ByID(2521603022, skipIncompleteLivePhotos);
 }
 
 export function SetUploadThreads(uploadThreads: number): $CancellablePromise<void> {

--- a/frontend/bindings/app/backend/index.ts
+++ b/frontend/bindings/app/backend/index.ts
@@ -12,6 +12,7 @@ export {
     Config,
     FileUploadResult,
     FilesDroppedEvent,
+    PreflightWarning,
     StartUploadEvent,
     ThreadStatus,
     UploadBatchStart

--- a/frontend/bindings/app/backend/models.ts
+++ b/frontend/bindings/app/backend/models.ts
@@ -85,6 +85,8 @@ export class Config {
     "saver": boolean;
     "recursive": boolean;
     "forceUpload": boolean;
+    "pairLivePhotos": boolean;
+    "skipIncompleteLivePhotos": boolean;
     "uploadThreads": number;
     "deleteFromHost": boolean;
     "disableUnsupportedFilesFilter": boolean;
@@ -115,6 +117,12 @@ export class Config {
         }
         if (!("forceUpload" in $$source)) {
             this["forceUpload"] = false;
+        }
+        if (!("pairLivePhotos" in $$source)) {
+            this["pairLivePhotos"] = false;
+        }
+        if (!("skipIncompleteLivePhotos" in $$source)) {
+            this["skipIncompleteLivePhotos"] = false;
         }
         if (!("uploadThreads" in $$source)) {
             this["uploadThreads"] = 0;
@@ -157,8 +165,11 @@ export class Config {
 export class FileUploadResult {
     "MediaKey": string;
     "IsError": boolean;
+    "IsLivePhoto": boolean;
+    "Skipped": boolean;
     "ErrorMessage": string;
     "Path": string;
+    "Paths": string[];
 
     /** Creates a new FileUploadResult instance. */
     constructor($$source: Partial<FileUploadResult> = {}) {
@@ -168,11 +179,20 @@ export class FileUploadResult {
         if (!("IsError" in $$source)) {
             this["IsError"] = false;
         }
+        if (!("IsLivePhoto" in $$source)) {
+            this["IsLivePhoto"] = false;
+        }
+        if (!("Skipped" in $$source)) {
+            this["Skipped"] = false;
+        }
         if (!("ErrorMessage" in $$source)) {
             this["ErrorMessage"] = "";
         }
         if (!("Path" in $$source)) {
             this["Path"] = "";
+        }
+        if (!("Paths" in $$source)) {
+            this["Paths"] = [];
         }
 
         Object.assign(this, $$source);
@@ -182,7 +202,11 @@ export class FileUploadResult {
      * Creates a new FileUploadResult instance from a string or object.
      */
     static createFrom($$source: any = {}): FileUploadResult {
+        const $$createField6_0 = $$createType0;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
+        if ("Paths" in $$parsedSource) {
+            $$parsedSource["Paths"] = $$createField6_0($$parsedSource["Paths"]);
+        }
         return new FileUploadResult($$parsedSource as Partial<FileUploadResult>);
     }
 }
@@ -219,6 +243,39 @@ export class FilesDroppedEvent {
     }
 }
 
+export class PreflightWarning {
+    "Paths": string[];
+    "Code": string;
+    "Message": string;
+
+    /** Creates a new PreflightWarning instance. */
+    constructor($$source: Partial<PreflightWarning> = {}) {
+        if (!("Paths" in $$source)) {
+            this["Paths"] = [];
+        }
+        if (!("Code" in $$source)) {
+            this["Code"] = "";
+        }
+        if (!("Message" in $$source)) {
+            this["Message"] = "";
+        }
+
+        Object.assign(this, $$source);
+    }
+
+    /**
+     * Creates a new PreflightWarning instance from a string or object.
+     */
+    static createFrom($$source: any = {}): PreflightWarning {
+        const $$createField0_0 = $$createType0;
+        let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
+        if ("Paths" in $$parsedSource) {
+            $$parsedSource["Paths"] = $$createField0_0($$parsedSource["Paths"]);
+        }
+        return new PreflightWarning($$parsedSource as Partial<PreflightWarning>);
+    }
+}
+
 /**
  * StartUploadEvent is received from frontend to start upload
  */
@@ -251,7 +308,7 @@ export class ThreadStatus {
     "WorkerID": number;
 
     /**
-     * "idle", "hashing", "checking", "uploading", "finalizing", "completed", "error"
+     * "idle", "hashing", "checking", "uploading", "finalizing", "completed", "skipped", "error"
      */
     "Status": string;
     "FilePath": string;

--- a/frontend/bindings/github.com/wailsapp/wails/v3/internal/eventcreate.ts
+++ b/frontend/bindings/github.com/wailsapp/wails/v3/internal/eventcreate.ts
@@ -18,8 +18,9 @@ function configure() {
         "albumError": $$createType3,
         "albumProgress": $$createType2,
         "files-dropped": $$createType4,
-        "startUpload": $$createType5,
-        "uploadStart": $$createType6,
+        "livePhotoPreflightWarning": $$createType5,
+        "startUpload": $$createType6,
+        "uploadStart": $$createType7,
     }));
 }
 
@@ -29,7 +30,8 @@ const $$createType1 = backend$0.ThreadStatus.createFrom;
 const $$createType2 = backend$0.AlbumStatus.createFrom;
 const $$createType3 = backend$0.AlbumError.createFrom;
 const $$createType4 = backend$0.FilesDroppedEvent.createFrom;
-const $$createType5 = backend$0.StartUploadEvent.createFrom;
-const $$createType6 = backend$0.UploadBatchStart.createFrom;
+const $$createType5 = backend$0.PreflightWarning.createFrom;
+const $$createType6 = backend$0.StartUploadEvent.createFrom;
+const $$createType7 = backend$0.UploadBatchStart.createFrom;
 
 configure();

--- a/frontend/bindings/github.com/wailsapp/wails/v3/internal/eventdata.d.ts
+++ b/frontend/bindings/github.com/wailsapp/wails/v3/internal/eventdata.d.ts
@@ -18,6 +18,7 @@ declare module "@wailsio/runtime" {
             "albumError": backend$0.AlbumError;
             "albumProgress": backend$0.AlbumStatus;
             "files-dropped": backend$0.FilesDroppedEvent;
+            "livePhotoPreflightWarning": backend$0.PreflightWarning;
             "startUpload": backend$0.StartUploadEvent;
             "uploadCancel": void;
             "uploadStart": backend$0.UploadBatchStart;

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -493,7 +493,7 @@ onUnmounted(() => {
           </Sheet>
 
           <div
-            v-if="uploadState.uploadedFiles > 0"
+            v-if="uploadState.uploadedFiles > 0 || uploadState.results.fail.length > 0"
             class="flex flex-col items-center gap-2 border rounded-lg p-5 mt-5"
           >
             <h2 class="text-l font-semibold select-none ">
@@ -501,6 +501,7 @@ onUnmounted(() => {
             </h2>
             <Label class="text-muted-foreground">Successful: {{ uploadState.results.success.length }}</Label>
             <Label class="text-muted-foreground">Failed: {{ uploadState.results.fail.length }}</Label>
+            <Label class="text-muted-foreground">Skipped: {{ uploadState.results.skipped.length }}</Label>
             <Button
               variant="outline"
               class="cursor-pointer select-none min-w-[125px]"

--- a/frontend/src/SettingsPanel.vue
+++ b/frontend/src/SettingsPanel.vue
@@ -176,7 +176,7 @@ watch(() => settings.value.uploadThreads, async (newValue) => {
         <Label
           for="pair-live-photos"
           class="cursor-pointer"
-        >Pair Live Photos</Label>
+        >Pair Apple Live Photos</Label>
         <p class="mt-0.5 text-[11px] leading-snug text-muted-foreground">
           Match Apple photos and MOV files by embedded metadata and upload them as one item.
         </p>
@@ -196,7 +196,8 @@ watch(() => settings.value.uploadThreads, async (newValue) => {
           class="cursor-pointer"
         >Skip Incomplete Live Photos</Label>
         <p class="mt-0.5 text-[11px] leading-snug text-muted-foreground">
-          Skip metadata-confirmed Live Photo files when their matching component is absent.
+          Only upload Live Photos when both photo and video are available. If either is missing,
+          don’t upload the remaining file separately.
         </p>
       </div>
       <Switch

--- a/frontend/src/SettingsPanel.vue
+++ b/frontend/src/SettingsPanel.vue
@@ -19,6 +19,8 @@ interface Settings {
     saver: boolean
     recursive: boolean
     forceUpload: boolean
+    pairLivePhotos: boolean
+    skipIncompleteLivePhotos: boolean
     deleteFromHost: boolean
     disableUnsupportedFilesFilter: boolean
     setDateFromFilename: boolean
@@ -31,6 +33,8 @@ const settings = ref<Settings>({
     saver: false,
     recursive: false,
     forceUpload: false,
+    pairLivePhotos: false,
+    skipIncompleteLivePhotos: false,
     deleteFromHost: false,
     disableUnsupportedFilesFilter: false,
     setDateFromFilename: false,
@@ -45,6 +49,8 @@ onMounted(async () => {
         saver: config.saver || false,
         recursive: config.recursive || false,
         forceUpload: config.forceUpload || false,
+        pairLivePhotos: config.pairLivePhotos || false,
+        skipIncompleteLivePhotos: config.skipIncompleteLivePhotos || false,
         deleteFromHost: config.deleteFromHost || false,
         disableUnsupportedFilesFilter: config.disableUnsupportedFilesFilter || false,
         setDateFromFilename: config.setDateFromFilename || false,
@@ -72,6 +78,14 @@ watch(() => settings.value.recursive, async (newValue) => {
 
 watch(() => settings.value.forceUpload, async (newValue) => {
     await ConfigManager.SetForceUpload(newValue)
+})
+
+watch(() => settings.value.pairLivePhotos, async (newValue) => {
+    await ConfigManager.SetPairLivePhotos(newValue)
+})
+
+watch(() => settings.value.skipIncompleteLivePhotos, async (newValue) => {
+    await ConfigManager.SetSkipIncompleteLivePhotos(newValue)
 })
 
 watch(() => settings.value.deleteFromHost, async (newValue) => {
@@ -152,6 +166,43 @@ watch(() => settings.value.uploadThreads, async (newValue) => {
       <Switch
         id="force-upload"
         v-model="settings.forceUpload"
+      />
+    </div>
+    <p class="-mt-1 text-[11px] leading-snug text-muted-foreground">
+      Applies to single files. Live Photo pairs always check both components for duplicates.
+    </p>
+    <div class="flex items-center justify-between">
+      <div class="pr-4">
+        <Label
+          for="pair-live-photos"
+          class="cursor-pointer"
+        >Pair Live Photos</Label>
+        <p class="mt-0.5 text-[11px] leading-snug text-muted-foreground">
+          Match Apple photos and MOV files by embedded metadata and upload them as one item.
+        </p>
+      </div>
+      <Switch
+        id="pair-live-photos"
+        v-model="settings.pairLivePhotos"
+      />
+    </div>
+    <div
+      class="flex items-center justify-between pl-4 transition-opacity"
+      :class="settings.pairLivePhotos ? 'opacity-100' : 'opacity-45'"
+    >
+      <div class="pr-4">
+        <Label
+          for="skip-incomplete-live-photos"
+          class="cursor-pointer"
+        >Skip Incomplete Live Photos</Label>
+        <p class="mt-0.5 text-[11px] leading-snug text-muted-foreground">
+          Skip metadata-confirmed Live Photo files when their matching component is absent.
+        </p>
+      </div>
+      <Switch
+        id="skip-incomplete-live-photos"
+        v-model="settings.skipIncompleteLivePhotos"
+        :disabled="!settings.pairLivePhotos"
       />
     </div>
     <div class="flex items-center justify-between">

--- a/frontend/src/Upload.vue
+++ b/frontend/src/Upload.vue
@@ -5,7 +5,7 @@ import { Progress } from "./components/ui/progress"
 import { ScrollArea } from "./components/ui/scroll-area"
 import ThreadProgress from "./components/ThreadProgress.vue"
 import { uploadManager } from './utils/UploadManager'
-import { X, Clock, Zap, FolderPlus } from '@lucide/vue'
+import { X, Clock, Zap, FolderPlus, AlertTriangle } from '@lucide/vue'
 
 const { state } = uploadManager
 
@@ -76,6 +76,10 @@ const albumProgressPercent = computed(() => {
   if (!state.albumStatus || state.albumStatus.TotalItems === 0) return 0
   return Math.round((state.albumStatus.ItemsAdded / state.albumStatus.TotalItems) * 100)
 })
+
+function warningFiles(paths: string[]): string {
+  return paths.map(path => path.split(/[\\/]/).pop()).filter(Boolean).join(', ')
+}
 </script>
 
 <template>
@@ -140,6 +144,30 @@ const albumProgressPercent = computed(() => {
       <p class="text-xs text-muted-foreground mt-1">
         {{ state.albumStatus.ItemsAdded }} / {{ state.albumStatus.TotalItems }} items
       </p>
+    </div>
+
+    <div
+      v-if="state.preflightWarnings.length"
+      class="mb-3 space-y-1.5"
+    >
+      <div
+        v-for="(warning, index) in state.preflightWarnings"
+        :key="`${warning.Code}-${index}`"
+        class="flex gap-2 rounded-md bg-amber-500/10 px-2.5 py-2 text-amber-700 dark:text-amber-300"
+      >
+        <AlertTriangle
+          :size="14"
+          class="mt-0.5 shrink-0"
+        />
+        <div class="min-w-0">
+          <p class="text-xs leading-snug">
+            {{ warning.Message }}
+          </p>
+          <p class="truncate text-[10px] opacity-75">
+            {{ warningFiles(warning.Paths) }}
+          </p>
+        </div>
+      </div>
     </div>
 
     <!-- Thread list - scrollable -->

--- a/frontend/src/components/ThreadProgress.vue
+++ b/frontend/src/components/ThreadProgress.vue
@@ -13,6 +13,8 @@ const statusConfig = computed(() => {
       return { color: 'text-destructive', bg: 'bg-destructive/10', label: 'Error' }
     case 'completed':
       return { color: 'text-primary', bg: 'bg-primary/10', label: 'Done' }
+    case 'skipped':
+      return { color: 'text-amber-700 dark:text-amber-300', bg: 'bg-amber-500/10', label: 'Skipped' }
     case 'uploading':
       if (props.thread.Attempt > 1) {
         return { color: 'text-orange-500', bg: 'bg-orange-500/10', label: `Retry ${props.thread.Attempt - 1}` }
@@ -94,8 +96,11 @@ const statusMessage = computed(() => props.thread.Message.replace(/^Error:\s*/, 
       </div>
     </template>
     <p
-      v-else-if="thread.Status === 'error'"
-      class="mt-1 text-[11px] leading-snug text-destructive break-words"
+      v-else-if="thread.Status === 'error' || thread.Status === 'skipped'"
+      :class="[
+        'mt-1 text-[11px] leading-snug break-words',
+        thread.Status === 'error' ? 'text-destructive' : 'text-muted-foreground'
+      ]"
     >
       {{ statusMessage }}
     </p>

--- a/frontend/src/utils/UploadManager.ts
+++ b/frontend/src/utils/UploadManager.ts
@@ -15,8 +15,17 @@ export interface ThreadStatus {
 export interface FileUploadResult {
   MediaKey: string;
   IsError: boolean;
+  IsLivePhoto: boolean;
+  Skipped: boolean;
   ErrorMessage: string;
   Path: string;
+  Paths: string[];
+}
+
+export interface PreflightWarning {
+  Paths: string[];
+  Code: string;
+  Message: string;
 }
 
 export interface UploadBatchStart {
@@ -50,7 +59,9 @@ export interface UploadState {
   results: {
     success: UploadSuccess[];
     fail: string[];
+    skipped: string[];
   };
+  preflightWarnings: PreflightWarning[];
   // Byte tracking
   totalBytes: number;
   uploadedBytes: number;
@@ -75,7 +86,9 @@ class UploadManager {
     results: {
       success: [],
       fail: [],
+      skipped: [],
     },
+    preflightWarnings: [],
     totalBytes: 0,
     uploadedBytes: 0,
     startTime: 0,
@@ -126,11 +139,16 @@ class UploadManager {
       this.completedBytes = 0;
       this.fileBytes.clear();
       this.resetUploadResults();
+      this.state.preflightWarnings = [];
     });
 
     // Handle async total bytes update (calculated after uploadStart)
     Events.On("uploadTotalBytes", (event: { data: number }) => {
       this.state.totalBytes = event.data;
+    });
+
+    Events.On("livePhotoPreflightWarning", (event: { data: PreflightWarning }) => {
+      this.state.preflightWarnings.push(event.data);
     });
 
     // Handle thread status updates
@@ -152,11 +170,15 @@ class UploadManager {
 
     // Handle file status updates
     Events.On("FileStatus", (event: { data: FileUploadResult }) => {
-      const { IsError, Path, MediaKey } = event.data;
+      const { IsError, Path, Paths, MediaKey, Skipped } = event.data;
 
       if (!IsError) {
         this.state.uploadedFiles += 1;
-        this.state.results.success.push({ path: Path, mediaKey: MediaKey });
+        if (Skipped) {
+          this.state.results.skipped.push(Path);
+        } else {
+          this.state.results.success.push({ path: Path, mediaKey: MediaKey });
+        }
         const completedFileBytes = this.fileBytes.get(Path);
         if (completedFileBytes && completedFileBytes > 0) {
           this.completedBytes += completedFileBytes;
@@ -165,7 +187,9 @@ class UploadManager {
         const errorMessage = event.data.ErrorMessage;
         this.state.results.fail.push(errorMessage ? `${Path}: ${errorMessage}` : Path);
       }
-      this.fileBytes.delete(Path);
+      for (const completedPath of Paths?.length ? Paths : [Path]) {
+        this.fileBytes.delete(completedPath);
+      }
       this.updateBytesAndSpeed();
     });
 
@@ -236,6 +260,7 @@ class UploadManager {
   public resetUploadResults() {
     this.state.results.success = [];
     this.state.results.fail = [];
+    this.state.results.skipped = [];
   }
 
   public cancelUpload() {

--- a/frontend/src/utils/UploadManager.ts
+++ b/frontend/src/utils/UploadManager.ts
@@ -1,5 +1,9 @@
 import { Clipboard, Events } from "@wailsio/runtime";
 import { reactive } from "vue";
+import {
+  recordUploadResult,
+  type UploadResults,
+} from "./uploadResults";
 
 export interface ThreadStatus {
   WorkerID: number;
@@ -18,6 +22,8 @@ export interface FileUploadResult {
   IsLivePhoto: boolean;
   Skipped: boolean;
   ErrorMessage: string;
+  SkipCode: string;
+  SkipReason: string;
   Path: string;
   Paths: string[];
 }
@@ -31,11 +37,6 @@ export interface PreflightWarning {
 export interface UploadBatchStart {
   Total: number;
   TotalBytes: number;
-}
-
-export interface UploadSuccess {
-  path: string;
-  mediaKey: string;
 }
 
 export interface AlbumStatus {
@@ -56,11 +57,7 @@ export interface UploadState {
   totalFiles: number;
   uploadedFiles: number;
   threads: Map<number, ThreadStatus>;
-  results: {
-    success: UploadSuccess[];
-    fail: string[];
-    skipped: string[];
-  };
+  results: UploadResults;
   preflightWarnings: PreflightWarning[];
   // Byte tracking
   totalBytes: number;
@@ -170,27 +167,30 @@ class UploadManager {
 
     // Handle file status updates
     Events.On("FileStatus", (event: { data: FileUploadResult }) => {
-      const { IsError, Path, Paths, MediaKey, Skipped } = event.data;
+      const { Path, Paths } = event.data;
 
-      if (!IsError) {
-        this.state.uploadedFiles += 1;
-        if (Skipped) {
-          this.state.results.skipped.push(Path);
-        } else {
-          this.state.results.success.push({ path: Path, mediaKey: MediaKey });
-        }
+      this.state.uploadedFiles += recordUploadResult(this.state.results, event.data);
+      if (!event.data.IsError) {
         const completedFileBytes = this.fileBytes.get(Path);
         if (completedFileBytes && completedFileBytes > 0) {
           this.completedBytes += completedFileBytes;
         }
-      } else {
-        const errorMessage = event.data.ErrorMessage;
-        this.state.results.fail.push(errorMessage ? `${Path}: ${errorMessage}` : Path);
       }
       for (const completedPath of Paths?.length ? Paths : [Path]) {
         this.fileBytes.delete(completedPath);
       }
       this.updateBytesAndSpeed();
+
+      // Skipped-only batches can begin and end within one backend event burst.
+      // Finishing locally prevents a missed terminal event from leaving the timer running.
+      if (
+        this.state.totalFiles > 0
+        && this.state.uploadedFiles >= this.state.totalFiles
+        && this.state.results.success.length === 0
+        && this.state.results.fail.length === 0
+      ) {
+        this.state.isUploading = false;
+      }
     });
 
     // Handle upload stop

--- a/frontend/src/utils/uploadResults.ts
+++ b/frontend/src/utils/uploadResults.ts
@@ -1,0 +1,47 @@
+export interface UploadSuccess {
+  path: string
+  mediaKey: string
+}
+
+export interface SkippedUploadResult {
+  paths: string[]
+  code: string
+  reason: string
+}
+
+export interface UploadResults {
+  success: UploadSuccess[]
+  fail: string[]
+  skipped: SkippedUploadResult[]
+}
+
+export interface UploadResultEvent {
+  MediaKey: string
+  IsError: boolean
+  Skipped: boolean
+  ErrorMessage: string
+  SkipCode: string
+  SkipReason: string
+  Path: string
+  Paths: string[]
+}
+
+export function recordUploadResult(results: UploadResults, event: UploadResultEvent): number {
+  if (event.IsError) {
+    results.fail.push(event.ErrorMessage ? `${event.Path}: ${event.ErrorMessage}` : event.Path)
+    return 1
+  }
+
+  if (event.Skipped) {
+    const paths = event.Paths?.length ? event.Paths : [event.Path]
+    results.skipped.push({
+      paths: paths.filter(Boolean),
+      code: event.SkipCode || 'skipped',
+      reason: event.SkipReason || 'Skipped by upload policy',
+    })
+    return 1
+  }
+
+  results.success.push({ path: event.Path, mediaKey: event.MediaKey })
+  return 1
+}


### PR DESCRIPTION
## Summary

Adds opt-in support for uploading Apple Live Photo photo/video pairs as a single item in Google Photos.

Pairs are matched using their embedded Apple content identifier rather than their filenames. The still image and MOV component are uploaded separately, then committed together using a linked create-media request.

Support is available in both the GUI and CLI.

## How this was determined

The upload flow was reconstructed by combining static analysis of the Google Photos iOS application with multiple intercepted uploads from the official client.

Comparing those requests identified:

- How the photo and video upload tokens are represented
- Which create-media protobuf fields link the components
- The required video SHA-1 and Live Photo metadata
- Which apparent fields are not part of this upload flow
- The stable response path containing the resulting media key

The implementation reproduces the observed request shape while keeping response parsing deliberately minimal.

## Changes

- Parse Apple Live Photo metadata from:
  - EXIF MakerNote tag 17 in HEIC/JPEG images
  - QuickTime content identifier and still-image-time metadata in MOV files
- Match photo and video components by embedded content identifier
- Preserve the complete raw Scotty finalize-token envelope required by the linked commit request
- Upload both components and commit them as one Google Photos media item
- Treat a complete pair as one logical upload work item
- Add deduplication checks for both components
- Add **Pair Apple Live Photos** and **Skip Incomplete Live Photos** settings
- Report skipped or incomplete pairs in the GUI upload results
- Add multi-path CLI uploads and Live Photo options:
  - `--pair-live-photos`
  - `--skip-incomplete-live-photos`
  - `--upload-incomplete-live-photos`
- Avoid retrying an accepted create-media request solely because its protobuf response could not be fully decoded

Settings page: 
<img width="377" height="471" alt="image" src="https://github.com/user-attachments/assets/15971050-a22c-4d80-98e0-61017263933c" />


## Behavior and limitations

- Live Photo pairing is disabled by default.
- When pairing is enabled, incomplete metadata-confirmed Live Photos are skipped by default.
- Ordinary HEIC, JPEG, and MOV files without Live Photo metadata continue to upload normally.
- Pairing is based on metadata, so filenames do not need to match.
- Ambiguous identifiers with multiple photo or video candidates are not paired automatically.
- This currently supports new pairs only.
- If either component already exists remotely, the complete pair is skipped. Reconciliation with partially existing remote pairs has not been implemented because that private request path has not been verified.
- **Force Upload** continues to apply to single-file uploads and does not bypass Live Photo pair deduplication.
- This implementation continues to uses existing Android authentication and storage-quality configuration. iOS credentials are not required.

## Validation

- Confirmed that a HEIC + MOV pair is displayed as one working Live Photo in Google Photos
- Confirmed that an unrelated single photo continues through the existing upload path
- Verified GUI and CLI builds
- Verified frontend lint and production build
- Verified skipped-item reporting and incomplete-pair handling

Protocol validation was performed against captured official-client traffic and representative Apple Live Photo files.