### PR TITLE
fix: support headless CLI uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ gotohp-cli version
   - `-a, --album <name>` - Add uploaded files to album (use `AUTO` for folder-based albums)
   - `-l, --log-level <level>` - Set log level: debug, info, warn, error (default: info)
   - `-c, --config <path>` - Path to config file
+  - `--no-tui` - Disable the interactive progress UI (selected automatically when stdin or stdout is not a terminal)
 - `creds list` (alias: `ls`) - List all credentials
 - `creds add <auth-string>` - Add new credentials
 - `creds remove <email>` (alias: `rm`) - Remove credentials

--- a/cli.go
+++ b/cli.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"os"
 	"strings"
 
 	"app/backend"
@@ -11,6 +12,7 @@ import (
 	"github.com/charmbracelet/bubbles/progress"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/term"
 )
 
 // CLI flags and config
@@ -25,6 +27,7 @@ type cliConfig struct {
 	logLevel                      string
 	configPath                    string
 	albumName                     string
+	noTUI                         bool
 }
 
 // Messages for bubbletea
@@ -259,6 +262,12 @@ func parseLogLevel(level string) slog.Level {
 	}
 }
 
+func shouldUseTUI(config cliConfig) bool {
+	return !config.noTUI &&
+		term.IsTerminal(os.Stdin.Fd()) &&
+		term.IsTerminal(os.Stdout.Fd())
+}
+
 // CLI upload implementation
 func runCLIUpload(filePaths []string, config cliConfig) error {
 	// Set custom config path if provided
@@ -293,9 +302,17 @@ func runCLIUpload(filePaths []string, config cliConfig) error {
 	// Parse log level
 	logLevel := parseLogLevel(config.logLevel)
 
-	// Start bubbletea program
+	// Start the upload event loop, with rendering and input only when interactive.
 	model := initialModel()
-	p := tea.NewProgram(model)
+	programOptions := []tea.ProgramOption{}
+	if !shouldUseTUI(config) {
+		programOptions = append(
+			programOptions,
+			tea.WithInput(nil),
+			tea.WithoutRenderer(),
+		)
+	}
+	p := tea.NewProgram(model, programOptions...)
 
 	// Create CLI app with event callback to bubbletea
 	eventCallback := func(event string, data any) {
@@ -360,13 +377,13 @@ func runCLIUpload(filePaths []string, config cliConfig) error {
 		uploadManager.Upload(cliApp, filePaths)
 	}()
 
-	// Run the TUI
+	// Run until the upload manager emits uploadStop.
 	finalModel, err := p.Run()
 	if err != nil {
-		return fmt.Errorf("error running TUI: %w", err)
+		return fmt.Errorf("error running upload program: %w", err)
 	}
 
-	// Print JSON summary after TUI completes
+	// Print JSON summary after the upload program completes.
 	if m, ok := finalModel.(uploadModel); ok {
 		summary := uploadSummary{
 			Total:     m.totalFiles,

--- a/cli_shared.go
+++ b/cli_shared.go
@@ -55,6 +55,7 @@ func runCLI() {
 			fmt.Println("                               Use 'AUTO' to create albums based on folder names")
 			fmt.Println("  -l, --log-level <level>      Set log level: debug, info, warn, error (default: info)")
 			fmt.Println("  -c, --config <path>          Path to config file")
+			fmt.Println("  --no-tui                     Disable the interactive progress UI")
 			return
 		}
 
@@ -93,6 +94,8 @@ func runCLI() {
 				config.disableUnsupportedFilesFilter = true
 			case "--date-from-filename":
 				config.setDateFromFilename = true
+			case "--no-tui":
+				config.noTUI = true
 			case "--exclude", "-e":
 				if i+1 < len(os.Args) {
 					config.excludePattern = os.Args[i+1]

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
+	github.com/charmbracelet/x/term v0.2.2
 	github.com/knadh/koanf/parsers/yaml v1.1.0
 	github.com/knadh/koanf/providers/file v1.2.1
 	github.com/knadh/koanf/providers/structs v1.0.0
@@ -23,7 +24,6 @@ require (
 	github.com/charmbracelet/harmonica v0.2.0 // indirect
 	github.com/charmbracelet/x/ansi v0.11.6 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
-	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/clipperhouse/displaywidth v0.9.0 // indirect
 	github.com/clipperhouse/stringish v0.1.1 // indirect
 	github.com/clipperhouse/uax29/v2 v2.5.0 // indirect


### PR DESCRIPTION
## Summary

- automatically disable the Bubble Tea UI when stdin or stdout is not a terminal
- add an explicit `--no-tui` upload flag and document it
- keep the existing Bubble Tea event loop in headless mode so the final JSON summary remains unchanged

Closes #70.

## Root cause

Bubble Tea opens `/dev/tty` when its default stdin is not a terminal. A systemd user service has no controlling terminal, so upload startup failed before progress handling could run.

Headless mode now passes both `tea.WithInput(nil)` and `tea.WithoutRenderer()`, preventing terminal access and ANSI rendering while preserving event processing.

## Validation

- `go mod tidy -diff`
- `go test -run '^$' -tags cli ./...`
- `go test -run '^$' ./...`
- `golangci-lint run ./...`
- built and smoke-tested both `gotohp` and `gotohp-cli` with automatic headless detection and `--no-tui`; all runs exited 0, emitted the expected JSON summary, and produced no TTY errors
- cross-compiled standalone CLI binaries for Linux amd64, macOS amd64, and macOS arm64
- independently reviewed for terminal handling, event ordering, cross-platform behavior, and output compatibility; no correctness blockers found