### PR TITLE
fix: cap QuickTime container nesting

### DIFF
--- a/backend/livephoto_metadata.go
+++ b/backend/livephoto_metadata.go
@@ -14,6 +14,7 @@ const (
 	appleMakerNoteHeader = "Apple iOS\x00"
 	maxMakerNoteScanSize = 64 << 20
 	maxContentIdentifier = 256
+	maxMP4BoxDepth       = 32
 )
 
 var ErrContentIdentifierMissing = errors.New("live photo content identifier is missing")
@@ -200,6 +201,13 @@ func readVideoLivePhotoMetadata(reader io.ReaderAt, size int64) (LivePhotoMetada
 }
 
 func walkMP4Boxes(reader io.ReaderAt, start, end int64, visit func(mp4Box) error) error {
+	return walkMP4BoxesAtDepth(reader, start, end, 0, visit)
+}
+
+func walkMP4BoxesAtDepth(reader io.ReaderAt, start, end int64, depth int, visit func(mp4Box) error) error {
+	if depth > maxMP4BoxDepth {
+		return fmt.Errorf("QuickTime box nesting exceeds %d levels", maxMP4BoxDepth)
+	}
 	for offset := start; offset < end; {
 		box, err := readMP4Box(reader, offset, end)
 		if err != nil {
@@ -220,7 +228,7 @@ func walkMP4Boxes(reader io.ReaderAt, start, end int64, visit func(mp4Box) error
 			if childStart > box.end {
 				return fmt.Errorf("invalid %s container", string(box.typ[:]))
 			}
-			if err := walkMP4Boxes(reader, childStart, box.end, visit); err != nil {
+			if err := walkMP4BoxesAtDepth(reader, childStart, box.end, depth+1, visit); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
## Summary

Caps recursive QuickTime/MP4 container traversal at 32 levels and returns a normal parse error when malformed media exceeds that limit.

## Why

`walkMP4Boxes` previously followed attacker-controlled nested container boxes without a depth bound. A malformed 800 KB MOV containing 100,000 nested `moov` boxes was accepted by the parser and kept a process busy for about 15.8 seconds. Greater nesting can continue growing the goroutine stack and turn one corrupt upload into process-wide availability pressure.

This follow-up addresses the high-priority finding from the completed Live Photo review: https://github.com/xob0t/gotohp/pull/74#discussion_r3684807909

## Validation

- The 100,000-level malformed MOV is rejected with `QuickTime box nesting exceeds 32 levels`.
- The public iPhone 15 HEIC+MOV Live Photo sample still parses successfully with matching content identifiers and `has_still_image_time=true`.
- `go build ./backend`
- `go build -tags cli -buildvcs=false`
- `go build ./...`

No regression tests were added or run, per repository instructions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added protection against excessively deep MP4 metadata structures.
  * Improved live photo metadata processing to prevent failures caused by deeply nested video data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->