### PR TITLE
fix: add webm to supported upload formats

### DIFF
--- a/backend/upload.go
+++ b/backend/upload.go
@@ -401,7 +401,7 @@ var supportedFormats = map[string]bool{
 	"3gp": true, "3g2": true, "asf": true, "avi": true, "divx": true,
 	"m2t": true, "m2ts": true, "m4v": true, "mkv": true, "mmv": true,
 	"mod": true, "mov": true, "mp4": true, "mpg": true, "mpeg": true,
-	"mts": true, "tod": true, "wmv": true, "ts": true,
+	"mts": true, "tod": true, "wmv": true, "ts": true, "webm": true,
 }
 
 // isSupportedByGooglePhotos checks if a file extension is supported by Google Photos


### PR DESCRIPTION
Fixes #75

Drag & dropping a `.webm` file into the GUI silently did nothing because `webm` was missing from the `supportedFormats` extension allowlist in `backend/upload.go`, so the file was filtered out before upload.

Google Photos accepts webm uploads — verified by uploading a VP9 `.webm` through the CLI with `--disable-filter`, which succeeded and returned a media key.

This adds `webm` to the supported video formats.