### PR TITLE
fix: make Wails dev server startup reliable

### DIFF
--- a/build/Taskfile.yml
+++ b/build/Taskfile.yml
@@ -168,8 +168,9 @@ tasks:
 
   dev:frontend:
     summary: Runs the frontend in development mode
-    deps:
-      - task: install:frontend:deps
+    # `wails3 dev` runs a blocking development build before this task, and that
+    # build already installs the frontend dependencies. Repeating the install
+    # here can exhaust Wails' five-second frontend readiness timeout.
     cmds:
       - task: frontend:dev:{{.PACKAGE_MANAGER}}
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,9 +5,12 @@ import { defineConfig } from 'vite'
 
 export default defineConfig({
   plugins: [vue(), tailwindcss()],
+  server: {
+    host: '127.0.0.1',
+  },
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, './src'),
+      '@': path.resolve(import.meta.dirname, './src'),
     },
   },
 })


### PR DESCRIPTION
Fixes two causes of wails3 dev startup failures: Vite now binds to the same IPv4 address Wails probes, and the background dev-server task no longer repeats npm install after the blocking development build already installed dependencies. Verified with two full Windows wails3 dev starts (including a Vite dependency re-optimization), plus frontend lint and production build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved frontend development startup by avoiding a redundant dependency-installation step.
  - Updated the development server to bind consistently to the local machine.
  - Improved path resolution for frontend module aliases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->