### PR TITLE
chore(deps): align Wails components on beta.12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ permissions:
   contents: write
 
 env:
-  WAILS_VERSION: v3.0.0-beta.8
+  WAILS_VERSION: v3.0.0-beta.12
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,7 +10,7 @@ permissions:
   pull-requests: write
 
 env:
-  WAILS_VERSION: v3.0.0-beta.8
+  WAILS_VERSION: v3.0.0-beta.12
 
 jobs:
   release-please:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -27,7 +27,7 @@
         "@iconify/vue": "^5.0.1",
         "@types/node": "^26.2.0",
         "@vitejs/plugin-vue": "^6.0.8",
-        "@wailsio/runtime": "3.0.0-beta.8",
+        "@wailsio/runtime": "3.0.0-beta.12",
         "autoprefixer": "^10.5.4",
         "eslint": "^10.8.1",
         "eslint-plugin-vue": "^10.10.0",
@@ -1537,9 +1537,9 @@
       }
     },
     "node_modules/@wailsio/runtime": {
-      "version": "3.0.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@wailsio/runtime/-/runtime-3.0.0-beta.8.tgz",
-      "integrity": "sha512-c9PZJcOR9z1a6cxtBS2q5cygNajlxDE8Oxv/vvcTFYRbZSoOGBszq4uzlkPTOd0Bot1xkM81jnpaBgKWRpBh2g==",
+      "version": "3.0.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@wailsio/runtime/-/runtime-3.0.0-beta.12.tgz",
+      "integrity": "sha512-2B456rspX5rDXYhNjRqXNDOPkRXjletGJ4R3beF2FGs7K67MTovLy9acXHYb8nolzL96kygyJ622RIjB45oumg==",
       "dev": true,
       "license": "MIT"
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,7 +34,7 @@
     "@iconify/vue": "^5.0.1",
     "@types/node": "^26.2.0",
     "@vitejs/plugin-vue": "^6.0.8",
-    "@wailsio/runtime": "3.0.0-beta.8",
+    "@wailsio/runtime": "3.0.0-beta.12",
     "autoprefixer": "^10.5.4",
     "eslint": "^10.8.1",
     "eslint-plugin-vue": "^10.10.0",


### PR DESCRIPTION
Pins the frontend runtime and CI-installed Wails CLI to v3.0.0-beta.12, matching the Go module. Verified with frontend build and lint, Go tests and vet, binding generation, Wails doctor, and a Windows desktop build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application’s Wails tooling and runtime to version `v3.0.0-beta.12`.
  * Aligns build, release, and frontend development environments with the latest beta version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->