### PR TITLE
ci: enforce pull request standards

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,24 @@
+name: PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  semantic-title:
+    name: Validate semantic PR title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          pattern='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([a-z0-9][a-z0-9._/-]*\))?!?: [a-z0-9].+$'
+
+          if [[ ! "$PR_TITLE" =~ $pattern ]]; then
+            echo "::error::Use a semantic title, for example: fix(settings): make rows clickable"
+            exit 1
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# Repository instructions
+
+## Pull requests
+
+- Keep each pull request limited to one focused change. Split unrelated work into separate pull requests.
+- Use a Conventional Commits title in the form `<type>(<optional-scope>): <description>`.
+- Allowed title types are `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, and `revert`.
+- Start the description with a lowercase letter. Example: `fix(settings): make Live Photo rows clickable`.


### PR DESCRIPTION
## Summary
- reject PR titles that do not follow the repository's Conventional Commits format
- rerun the check when a PR title changes
- tell agents to keep each PR limited to one focused change

## Verification
- actionlint .github/workflows/pr-title.yml
- tested accepted and rejected title examples