### PR TITLE
fix(config): serialize persistent updates

### DIFF
--- a/backend/configmanager.go
+++ b/backend/configmanager.go
@@ -71,67 +71,78 @@ func ParseAuthString(authString string) (url.Values, error) {
 }
 
 func (g *ConfigManager) SetProxy(proxy string) {
-	AppConfig.Proxy = proxy
-	_ = saveAppConfig()
+	updateAppConfig(func(config *Config) {
+		config.Proxy = proxy
+	})
 }
 
 func (g *ConfigManager) SetSelected(email string) {
-	// Parse the auth string
-	AppConfig.Selected = email
-	_ = saveAppConfig()
+	updateAppConfig(func(config *Config) {
+		config.Selected = email
+	})
 }
 
 func (g *ConfigManager) SetUseQuota(useQuota bool) {
-	AppConfig.UseQuota = useQuota
-	_ = saveAppConfig()
+	updateAppConfig(func(config *Config) {
+		config.UseQuota = useQuota
+	})
 }
 
 func (g *ConfigManager) SetSaver(saver bool) {
-	AppConfig.Saver = saver
-	_ = saveAppConfig()
+	updateAppConfig(func(config *Config) {
+		config.Saver = saver
+	})
 }
 
 func (g *ConfigManager) SetRecursive(recursive bool) {
-	AppConfig.Recursive = recursive
-	_ = saveAppConfig()
+	updateAppConfig(func(config *Config) {
+		config.Recursive = recursive
+	})
 }
 
 func (g *ConfigManager) SetForceUpload(forceUpload bool) {
-	AppConfig.ForceUpload = forceUpload
-	_ = saveAppConfig()
+	updateAppConfig(func(config *Config) {
+		config.ForceUpload = forceUpload
+	})
 }
 
 func (g *ConfigManager) SetPairLivePhotos(pairLivePhotos bool) {
-	AppConfig.PairLivePhotos = pairLivePhotos
-	_ = saveAppConfig()
+	updateAppConfig(func(config *Config) {
+		config.PairLivePhotos = pairLivePhotos
+	})
 }
 
 func (g *ConfigManager) SetSkipIncompleteLivePhotos(skipIncompleteLivePhotos bool) {
-	AppConfig.SkipIncompleteLivePhotos = skipIncompleteLivePhotos
-	_ = saveAppConfig()
+	updateAppConfig(func(config *Config) {
+		config.SkipIncompleteLivePhotos = skipIncompleteLivePhotos
+	})
 }
 
 func (g *ConfigManager) SetUpdateExistingPhotosToLive(updateExistingPhotosToLive bool) {
-	AppConfig.UpdateExistingPhotosToLive = updateExistingPhotosToLive
-	_ = saveAppConfig()
+	updateAppConfig(func(config *Config) {
+		config.UpdateExistingPhotosToLive = updateExistingPhotosToLive
+	})
 }
 
 func (g *ConfigManager) SetDeleteFromHost(deleteFromHost bool) {
-	AppConfig.DeleteFromHost = deleteFromHost
-	_ = saveAppConfig()
+	updateAppConfig(func(config *Config) {
+		config.DeleteFromHost = deleteFromHost
+	})
 }
 
 func (g *ConfigManager) SetDisableUnsupportedFilesFilter(disableUnsupportedFilesFilter bool) {
-	AppConfig.DisableUnsupportedFilesFilter = disableUnsupportedFilesFilter
-	_ = saveAppConfig()
+	updateAppConfig(func(config *Config) {
+		config.DisableUnsupportedFilesFilter = disableUnsupportedFilesFilter
+	})
 }
 
 func (g *ConfigManager) SetUploadThreads(uploadThreads int) {
 	if uploadThreads < 1 {
 		return
 	}
-	AppConfig.UploadThreads = uploadThreads
-	_ = saveAppConfig()
+	updateAppConfig(func(config *Config) {
+		config.UploadThreads = uploadThreads
+	})
 }
 
 func (g *ConfigManager) SetAlbumName(albumName string) {
@@ -167,13 +178,15 @@ func GetAlbumConfig() (albumName string, autoMode bool) {
 }
 
 func (g *ConfigManager) SetSetDateFromFilename(v bool) {
-	AppConfig.SetDateFromFilename = v
-	_ = saveAppConfig()
+	updateAppConfig(func(config *Config) {
+		config.SetDateFromFilename = v
+	})
 }
 
 func (g *ConfigManager) SetExcludePattern(pattern string) {
-	AppConfig.ExcludePattern = pattern
-	_ = saveAppConfig()
+	updateAppConfig(func(config *Config) {
+		config.ExcludePattern = pattern
+	})
 }
 
 func (g *ConfigManager) GetExcludePattern() string {
@@ -217,6 +230,9 @@ func (g *ConfigManager) AddCredentials(newAuthString string) error {
 		return fmt.Errorf("email cannot be empty")
 	}
 
+	configMu.Lock()
+	defer configMu.Unlock()
+
 	// Check for duplicate email in existing credentials
 	for _, cred := range AppConfig.Credentials {
 		existingParams, err := url.ParseQuery(cred)
@@ -231,7 +247,7 @@ func (g *ConfigManager) AddCredentials(newAuthString string) error {
 	// If validation passed, add the new credentials
 	AppConfig.Credentials = append(AppConfig.Credentials, newAuthString)
 	AppConfig.Selected = email
-	_ = saveAppConfig()
+	_ = saveAppConfigLocked()
 	return nil
 }
 
@@ -254,6 +270,9 @@ func (g *ConfigManager) AddTokenBindingAliasFromADB(email string) error {
 		return err
 	}
 
+	configMu.Lock()
+	defer configMu.Unlock()
+
 	for i, cred := range AppConfig.Credentials {
 		params, err := url.ParseQuery(cred)
 		if err != nil {
@@ -264,7 +283,7 @@ func (g *ConfigManager) AddTokenBindingAliasFromADB(email string) error {
 		}
 		params.Set("token_binding_alias", alias)
 		AppConfig.Credentials[i] = params.Encode()
-		return saveAppConfig()
+		return saveAppConfigLocked()
 	}
 
 	return fmt.Errorf("no credentials found for email %s", email)
@@ -274,6 +293,9 @@ func (g *ConfigManager) RemoveCredentials(email string) error {
 	if email == "" {
 		return fmt.Errorf("email cannot be empty")
 	}
+
+	configMu.Lock()
+	defer configMu.Unlock()
 
 	// Find and remove the credential with matching email
 	found := false
@@ -305,7 +327,7 @@ func (g *ConfigManager) RemoveCredentials(email string) error {
 		AppConfig.Selected = ""
 	}
 
-	_ = saveAppConfig()
+	_ = saveAppConfigLocked()
 	return nil
 }
 
@@ -629,7 +651,16 @@ func loadConfigLocked() error {
 	return nil
 }
 
-func saveAppConfig() error {
+func updateAppConfig(update func(*Config)) {
+	configMu.Lock()
+	defer configMu.Unlock()
+
+	update(&AppConfig)
+	_ = saveAppConfigLocked()
+}
+
+// saveAppConfigLocked persists AppConfig while the caller holds configMu for writing.
+func saveAppConfigLocked() error {
 	k := koanf.New(".")
 
 	err := k.Load(structs.Provider(AppConfig, "koanf"), nil)

--- a/backend/googleauth.go
+++ b/backend/googleauth.go
@@ -317,7 +317,7 @@ func upsertCredential(credential string) error {
 	}
 	AppConfig.Selected = email
 
-	if err := saveAppConfig(); err != nil {
+	if err := saveAppConfigLocked(); err != nil {
 		AppConfig.Credentials = previousCredentials
 		AppConfig.Selected = previousSelected
 		return err

--- a/backend/googleauth_test.go
+++ b/backend/googleauth_test.go
@@ -14,6 +14,7 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -340,6 +341,49 @@ func TestWriteConfigAtomicallyReplacesExistingFile(t *testing.T) {
 		if permissions := info.Mode().Perm(); permissions != 0o600 {
 			t.Fatalf("config permissions = %o, want 600", permissions)
 		}
+	}
+}
+
+func TestConcurrentSettingsWritesPersistLatestState(t *testing.T) {
+	restoreConfigGlobals(t)
+
+	configMu.Lock()
+	AppConfig = DefaultConfig
+	ConfigPath = filepath.Join(t.TempDir(), "gotohp.config")
+	configMu.Unlock()
+
+	manager := &ConfigManager{}
+	var writes sync.WaitGroup
+	for index := 1; index <= 16; index++ {
+		index := index
+		writes.Add(2)
+		go func() {
+			defer writes.Done()
+			manager.SetProxy(fmt.Sprintf("proxy-%d", index))
+		}()
+		go func() {
+			defer writes.Done()
+			manager.SetUploadThreads(index)
+		}()
+	}
+	writes.Wait()
+
+	configMu.RLock()
+	wantProxy := AppConfig.Proxy
+	wantUploadThreads := AppConfig.UploadThreads
+	path := ConfigPath
+	configMu.RUnlock()
+
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read saved config: %v", err)
+	}
+	saved := string(contents)
+	if !strings.Contains(saved, fmt.Sprintf("proxy: %s", wantProxy)) {
+		t.Fatalf("saved proxy does not match memory: want %q in %s", wantProxy, saved)
+	}
+	if !strings.Contains(saved, fmt.Sprintf("upload_threads: %d", wantUploadThreads)) {
+		t.Fatalf("saved upload threads do not match memory: want %d in %s", wantUploadThreads, saved)
 	}
 }
 


### PR DESCRIPTION
Serializes persistent configuration mutations and atomic file writes under configMu so concurrent setters cannot race or leave disk state behind memory. Adds a concurrent persistence regression test.

Tests: go test -race ./backend; go test ./...; go vet ./...; golangci-lint run --disable staticcheck ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when saving configuration changes made concurrently.
  * Ensured credential updates, removals, and token-binding changes are persisted consistently.
* **Tests**
  * Added coverage for simultaneous configuration updates to verify persisted settings remain accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->