### PR TITLE
fix(cli): accept an Embedded Setup oauth_token in creds add

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ Download the `gotohp-cli` release artifact for your platform. It runs without th
 
 ```shell
 gotohp-cli upload /path/to/photos --recursive --threads 5
-gotohp-cli creds add "androidId=..."
+gotohp-cli creds add "<oauth_token cookie value>"   # Embedded Setup sign-in, see below
+gotohp-cli creds add "androidId=..."                 # or a raw credential string
+gotohp-cli creds add - < token.txt                   # or read either from stdin
 gotohp-cli creds set user@gmail.com
 ```
 
@@ -43,6 +45,8 @@ The GUI binary runs the same CLI when given a command, e.g. `gotohp upload ...`.
 4. Open the browser developer tools. Under Application or Storage, open Cookies for `accounts.google.com`.
 5. Copy only the value of the `oauth_token` cookie and paste it into gotohp.
 6. Click **Connect account**.
+
+From the CLI, open the same page yourself and run `gotohp-cli creds add "<oauth_token value>"`.
 
 ### Option 2 - ReVanced. No root required
 

--- a/backend/configmanager.go
+++ b/backend/configmanager.go
@@ -121,6 +121,20 @@ func ParseAuthString(authString string) (url.Values, error) {
 	return url.ParseQuery(authString)
 }
 
+// LooksLikeAuthString reports whether value is a raw credential (a query string
+// with Email and Token keys) rather than an Embedded Setup oauth_token.
+func LooksLikeAuthString(value string) bool {
+	value = strings.TrimSpace(value)
+	if !strings.Contains(value, "=") {
+		return false
+	}
+	params, err := url.ParseQuery(value)
+	if err != nil {
+		return false
+	}
+	return params.Get("Email") != "" && params.Get("Token") != ""
+}
+
 func (g *ConfigManager) SetProxy(proxy string) {
 	updateAppConfig(func(config *Config) {
 		config.Preferences.Proxy = proxy

--- a/backend/googleauth.go
+++ b/backend/googleauth.go
@@ -36,6 +36,8 @@ type googleAuthExchange struct {
 	MasterToken string
 }
 
+// AddGoogleAccount exchanges an Embedded Setup oauth_token for a Google Photos
+// credential using the GUI's proxy preference, saves it, and returns the email.
 func (g *ConfigManager) AddGoogleAccount(oauthToken string) (string, error) {
 	ensureConfigLoaded()
 
@@ -43,6 +45,14 @@ func (g *ConfigManager) AddGoogleAccount(oauthToken string) (string, error) {
 	proxy := AppConfig.Preferences.Proxy
 	configMu.RUnlock()
 
+	return g.AddGoogleAccountWithProxy(oauthToken, proxy)
+}
+
+// AddGoogleAccountWithProxy is AddGoogleAccount with an explicit proxy, for
+// callers such as the CLI that do not use GUI preferences.
+//
+//wails:ignore
+func (g *ConfigManager) AddGoogleAccountWithProxy(oauthToken string, proxy string) (string, error) {
 	client, err := newGoogleAuthHTTPClient(proxy)
 	if err != nil {
 		return "", fmt.Errorf("prepare Google authentication: %w", err)

--- a/backend/googleauth_test.go
+++ b/backend/googleauth_test.go
@@ -398,3 +398,19 @@ func restoreConfigGlobals(t *testing.T) {
 		configMu.Unlock()
 	})
 }
+
+func TestLooksLikeAuthString(t *testing.T) {
+	cases := map[string]bool{
+		"androidId=1&Email=a%40x.com&Token=t":            true,
+		"  Email=a%40x.com&Token=t  ":                    true,
+		"Email=a%40x.com":                                false,
+		"oauth_token=abcdefghijklmnopqrstuvwxyz":         false,
+		"4/0AbCdEfGhIjKlMnOpQrStUvWxYz-1234567890abcdef": false,
+		"": false,
+	}
+	for in, want := range cases {
+		if got := LooksLikeAuthString(in); got != want {
+			t.Errorf("LooksLikeAuthString(%q) = %v, want %v", in, got, want)
+		}
+	}
+}

--- a/frontend/bindings/app/backend/configmanager.ts
+++ b/frontend/bindings/app/backend/configmanager.ts
@@ -13,6 +13,10 @@ export function AddCredentials(newAuthString: string): $CancellablePromise<void>
     return $Call.ByID(4083250689, newAuthString);
 }
 
+/**
+ * AddGoogleAccount exchanges an Embedded Setup oauth_token for a Google Photos
+ * credential using the GUI's proxy preference, saves it, and returns the email.
+ */
 export function AddGoogleAccount(oauthToken: string): $CancellablePromise<string> {
     return $Call.ByID(733209449, oauthToken);
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1,6 +1,10 @@
 package cli
 
-import "testing"
+import (
+	"io"
+	"strings"
+	"testing"
+)
 
 func TestIsCLIInvocation(t *testing.T) {
 	cases := []struct {
@@ -24,5 +28,30 @@ func TestIsCLIInvocation(t *testing.T) {
 		if got := IsCLIInvocation(c.args); got != c.want {
 			t.Errorf("IsCLIInvocation(%q) = %v, want %v", c.args, got, c.want)
 		}
+	}
+}
+
+func TestReadSecretArg(t *testing.T) {
+	if got, err := readSecretArg("literal", strings.NewReader("ignored")); err != nil || got != "literal" {
+		t.Fatalf("literal: got %q, %v", got, err)
+	}
+	if got, err := readSecretArg("-", strings.NewReader("  token-value \r\nsecond line\n")); err != nil || got != "token-value" {
+		t.Fatalf("stdin: got %q, %v", got, err)
+	}
+	if _, err := readSecretArg("-", strings.NewReader("\n")); err == nil {
+		t.Fatal("empty stdin: expected error")
+	}
+	if got, err := readSecretArg("-", strings.NewReader("no-trailing-newline")); err != nil || got != "no-trailing-newline" {
+		t.Fatalf("eof without newline: got %q, %v", got, err)
+	}
+	// Must return after the first line without waiting for EOF on the reader.
+	pr, pw := io.Pipe()
+	go func() { _, _ = io.WriteString(pw, "first\n") }()
+	if got, err := readSecretArg("-", pr); err != nil || got != "first" {
+		t.Fatalf("open pipe: got %q, %v", got, err)
+	}
+	_ = pw.Close()
+	if _, err := readSecretArg("-", strings.NewReader(strings.Repeat("x", maxSecretLen+1)+"\n")); err == nil {
+		t.Fatal("overlong: expected error")
 	}
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -51,7 +51,11 @@ func TestReadSecretArg(t *testing.T) {
 		t.Fatalf("open pipe: got %q, %v", got, err)
 	}
 	_ = pw.Close()
-	if _, err := readSecretArg("-", strings.NewReader(strings.Repeat("x", maxSecretLen+1)+"\n")); err == nil {
+	exact := strings.Repeat("x", maxSecretLen)
+	if got, err := readSecretArg("-", strings.NewReader(exact+"\r\n")); err != nil || got != exact {
+		t.Fatalf("exact limit: len=%d, %v", len(got), err)
+	}
+	if _, err := readSecretArg("-", strings.NewReader(exact+"x\n")); err == nil {
 		t.Fatal("overlong: expected error")
 	}
 }

--- a/internal/cli/credentials.go
+++ b/internal/cli/credentials.go
@@ -111,14 +111,16 @@ func readSecretArg(arg string, in io.Reader) (string, error) {
 	if arg != "-" {
 		return arg, nil
 	}
-	line, err := bufio.NewReader(io.LimitReader(in, maxSecretLen+1)).ReadString('\n')
+	// Allow the limit plus a line terminator, then measure the content alone.
+	line, err := bufio.NewReader(io.LimitReader(in, maxSecretLen+3)).ReadString('\n')
 	if err != nil && !errors.Is(err, io.EOF) {
 		return "", fmt.Errorf("reading value from stdin: %w", err)
 	}
-	if len(line) > maxSecretLen {
+	content := strings.TrimSuffix(strings.TrimSuffix(line, "\n"), "\r")
+	if len(content) > maxSecretLen {
 		return "", fmt.Errorf("value on stdin exceeds %d bytes", maxSecretLen)
 	}
-	value := strings.TrimSpace(line)
+	value := strings.TrimSpace(content)
 	if value == "" {
 		return "", fmt.Errorf("no value received on stdin")
 	}

--- a/internal/cli/credentials.go
+++ b/internal/cli/credentials.go
@@ -1,7 +1,10 @@
 package cli
 
 import (
+	"bufio"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -23,19 +26,46 @@ func newCredentialsCommand() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.AddCommand(
-		&cobra.Command{
-			Use:   "add <auth-string>",
-			Short: "Add a new credential",
-			Args:  cobra.ExactArgs(1),
-			RunE: func(_ *cobra.Command, args []string) error {
-				if err := (&backend.ConfigManager{}).AddCredentials(args[0]); err != nil {
+
+	add := &cobra.Command{
+		Use:   "add <auth-string | oauth-token>",
+		Short: "Add an account from a raw auth string or an Embedded Setup oauth_token cookie",
+		Long: `Add an account.
+
+Pass either a raw credential string (androidId=...&Email=...&Token=...) or the
+oauth_token cookie value from https://accounts.google.com/EmbeddedSetup. A cookie
+is exchanged with Google for a credential, validated, and saved; the account
+becomes the selected one.
+
+Pass "-" to read the value from standard input instead, which keeps it out of
+shell history and process listings.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			value, err := readSecretArg(args[0], cmd.InOrStdin())
+			if err != nil {
+				return err
+			}
+			configManager := &backend.ConfigManager{}
+			if backend.LooksLikeAuthString(value) {
+				if err := configManager.AddCredentials(value); err != nil {
 					return fmt.Errorf("adding credentials: %w", err)
 				}
 				fmt.Println("✓ Credentials added successfully")
 				return nil
-			},
+			}
+			proxy, _ := cmd.Flags().GetString("proxy")
+			email, err := configManager.AddGoogleAccountWithProxy(value, proxy)
+			if err != nil {
+				return fmt.Errorf("signing in with oauth_token: %w", err)
+			}
+			fmt.Printf("✓ Account %s connected and selected\n", email)
+			return nil
 		},
+	}
+	add.Flags().String("proxy", "", "proxy URL for the sign-in exchange")
+
+	cmd.AddCommand(
+		add,
 		&cobra.Command{
 			Use:     "remove <email>",
 			Aliases: []string{"rm"},
@@ -70,6 +100,29 @@ func newCredentialsCommand() *cobra.Command {
 		},
 	)
 	return cmd
+}
+
+// maxSecretLen bounds a credential or oauth_token read from stdin.
+const maxSecretLen = 64 * 1024
+
+// readSecretArg returns arg, or the first line of in when arg is "-". It stops
+// at the newline so interactive use does not wait for EOF.
+func readSecretArg(arg string, in io.Reader) (string, error) {
+	if arg != "-" {
+		return arg, nil
+	}
+	line, err := bufio.NewReader(io.LimitReader(in, maxSecretLen+1)).ReadString('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return "", fmt.Errorf("reading value from stdin: %w", err)
+	}
+	if len(line) > maxSecretLen {
+		return "", fmt.Errorf("value on stdin exceeds %d bytes", maxSecretLen)
+	}
+	value := strings.TrimSpace(line)
+	if value == "" {
+		return "", fmt.Errorf("no value received on stdin")
+	}
+	return value, nil
 }
 
 func credentialEmails(config backend.Config) []string {


### PR DESCRIPTION
Stacked on #96. Retarget to `main` once that merges.

## What this does

#89 added browser-based sign-in to the GUI. The CLI never got it, so `gotohp-cli creds add` only took a raw auth string. This brings the CLI to parity.

`creds add <value>` now accepts either input. If the value parses as a credential (a query string with `Email` and `Token`), it goes through `AddCredentials` as before. Anything else is treated as the `oauth_token` cookie from https://accounts.google.com/EmbeddedSetup and exchanged with Google through the same backend path the GUI uses, then validated and saved. A `--proxy` flag covers the exchange, since the CLI does not read GUI preferences.

`creds add -` reads the value from stdin. It reads one line, bounded at 64 KiB, and returns as soon as the newline arrives, so interactive use does not wait for EOF. This is the escape hatch for scripts that need to keep secrets out of shell history and process listings. The positional form stays, since it predates this change and the oauth_token is single-use anyway.

## Backend

`AddGoogleAccount` (GUI) now wraps a new `AddGoogleAccountWithProxy`, marked `wails:ignore`, which is what the CLI calls. `LooksLikeAuthString` decides which path a value takes.

## Testing

`go test ./...`, `go vet` under both build tags.

`TestLooksLikeAuthString` and `TestReadSecretArg` cover the new logic, including an open pipe that sends one line and never closes. Smoke run on the `cli` build: a too-short token is rejected locally, a bogus token reaches Google and comes back as HTTP 403 without echoing the value, a raw string still works, and `creds add - < file` works.

I have not done a real browser sign-in through the CLI. The exchange, validation and save are the same code the GUI runs, and that flow is confirmed working there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CLI support for credential strings, Google OAuth cookie values, and secrets read from stdin.
  * Added proxy configuration for Google OAuth sign-in.
  * OAuth accounts are validated, saved, and selected automatically.
* **Documentation**
  * Expanded setup guidance for credential formats and the Embedded Setup sign-in flow.
* **Bug Fixes**
  * Improved handling of empty, malformed, oversized, or unreadable credential input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->